### PR TITLE
fix: remove hardcoded database credentials from migration script

### DIFF
--- a/apps/api/src/infrastructure/database/run-migrations.ts
+++ b/apps/api/src/infrastructure/database/run-migrations.ts
@@ -9,8 +9,10 @@ function log(level: string, msg: string, extra?: Record<string, unknown>): void 
 }
 
 async function runMigrations(): Promise<void> {
-  const connectionString =
-    process.env.DATABASE_URL ?? 'postgresql://cycling:cycling@localhost:5432/cycling_analyzer';
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL environment variable is required');
+  }
+  const connectionString = process.env.DATABASE_URL;
 
   const pool = new Pool({ connectionString });
   const db = drizzle(pool);


### PR DESCRIPTION
## Summary

- Remove default `postgresql://cycling:cycling@...` fallback from `run-migrations.ts`
- Script now fails explicitly with `DATABASE_URL environment variable is required` if not set
- The migration script only runs in production (container entrypoint), where `DATABASE_URL` is always provided via Dokploy

`drizzle.provider.ts` keeps its fallback intentionally — it's used in local dev where `docker-compose.yml` provides the default Postgres instance.

## Test plan

- [x] TypeScript compiles clean
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)