### PR TITLE
refactor: remove broken comeback signal from BPI

### DIFF
--- a/apps/api/src/domain/breakout/__tests__/breakout.service.spec.ts
+++ b/apps/api/src/domain/breakout/__tests__/breakout.service.spec.ts
@@ -6,7 +6,6 @@ const BreakoutFlag = {
   EmergingTalent: 'EMERGING_TALENT',
   HotStreak: 'HOT_STREAK',
   DeepValue: 'DEEP_VALUE',
-  Comeback: 'COMEBACK',
   SprintOpportunity: 'SPRINT_OPPORTUNITY',
   BreakawayHunter: 'BREAKAWAY_HUNTER',
   RaceSpecialist: 'RACE_SPECIALIST',
@@ -16,7 +15,6 @@ import {
   computeRawSlope,
   computeTrajectory,
   computeForm,
-  computeComeback,
   computeRouteFit,
   computeVariance,
   computeBpiIndex,
@@ -113,7 +111,7 @@ describe('computeTrajectory', () => {
 
   it('applies age factor 1.5 for age < 25', () => {
     const seasons = [makeSeason(2024, 50), makeSeason(2025, 60)];
-    // slope = 10, factor 1.5 → 15
+    // slope = 10, factor 1.5 -> 15
     expect(computeTrajectory(seasons, youngBirthDate, NOW)).toBe(15);
   });
 
@@ -124,7 +122,7 @@ describe('computeTrajectory', () => {
 
   it('applies age factor 0.5 for age 28-31', () => {
     const seasons = [makeSeason(2024, 50), makeSeason(2025, 60)];
-    // default age 28, factor 0.5 → 5
+    // default age 28, factor 0.5 -> 5
     expect(computeTrajectory(seasons, null, NOW)).toBe(5);
   });
 
@@ -133,10 +131,10 @@ describe('computeTrajectory', () => {
     expect(computeTrajectory(seasons, oldBirthDate, NOW)).toBe(2);
   });
 
-  it('clamps at 25', () => {
+  it('clamps at 30', () => {
     const seasons = [makeSeason(2024, 0), makeSeason(2025, 200)];
-    // slope = 200, factor 1.5 → 300 → clamped to 25
-    expect(computeTrajectory(seasons, youngBirthDate, NOW)).toBe(25);
+    // slope = 200, factor 1.5 -> 300 -> clamped to 30
+    expect(computeTrajectory(seasons, youngBirthDate, NOW)).toBe(30);
   });
 });
 
@@ -158,18 +156,18 @@ describe('computeForm', () => {
   });
 
   it('computes ratio-based score for hot form', () => {
-    // Recent: 200 avg. Career: [200, 80, 80] avg=120. Ratio=200/120=1.667. Score=(0.667)*25=16.67
+    // Recent: 200 avg. Career: [200, 80, 80] avg=120. Ratio=200/120=1.667. Score=(0.667)*30=20
     const perfs = [
       makePerf('race-a', 2026, 10, 200),
       makePerf('race-b', 2025, 120, 80),
       makePerf('race-c', 2025, 200, 80),
     ];
     const score = computeForm(perfs, NOW);
-    expect(score).toBeCloseTo(16.67, 0);
+    expect(score).toBeCloseTo(20, 0);
   });
 
   it('returns 0 when recent equals career avg', () => {
-    // All races have same total → ratio = 1 → score = 0
+    // All races have same total -> ratio = 1 -> score = 0
     const perfs = [
       makePerf('race-a', 2026, 10, 100),
       makePerf('race-b', 2025, 120, 100),
@@ -178,65 +176,18 @@ describe('computeForm', () => {
     expect(computeForm(perfs, NOW)).toBe(0);
   });
 
-  it('clamps at 25', () => {
-    // Recent: 300, Career: [300, 50] avg=175. Ratio=1.71 → score=17.9. Not clamped yet.
-    // Recent: 500, Career: [500, 50] avg=275. Ratio=1.82 → score=20.5. Still not clamped.
-    // Recent: 1000, Career: [1000, 50] avg=525. Ratio=1.905 → 22.6. Not quite.
-    // Use extreme: recent 500, old 10 → avg=255, ratio=1.96 → 24.0
-    // Even more: recent 500, old 1 → avg=250.5, ratio=1.996 → 24.9
-    // Force clamp: recent 1000, old 1 → avg=500.5, ratio=1.998 → 24.95
-    // Actually need ratio >= 2 for clamp. recent 200, old single 10 → avg=105, ratio=1.9 → 23.8
-    // Simpler: just make a case where ratio > 2
+  it('clamps at 30', () => {
     const perfs = [
       makePerf('race-a', 2026, 10, 300),
       makePerf('race-b', 2024, 400, 50),
       makePerf('race-c', 2023, 500, 50),
     ];
-    // Recent avg=300, career avg=(300+50+50)/3=133.3, ratio=2.25, score=(1.25)*25=31.25 → clamped 25
-    expect(computeForm(perfs, NOW)).toBe(25);
+    // Recent avg=300, career avg=(300+50+50)/3=133.3, ratio=2.25, score=(1.25)*30=37.5 -> clamped 30
+    expect(computeForm(perfs, NOW)).toBe(30);
   });
 });
 
-// ── Signal 3: Comeback ──────────────────────────────────────────────
-
-describe('computeComeback', () => {
-  it('returns 0 for age > 33', () => {
-    expect(computeComeback([makeSeason(2020, 300)], 100, oldBirthDate, 10, 10, NOW)).toBe(0);
-  });
-
-  it('returns 0 for empty seasons', () => {
-    expect(computeComeback([], 100, null, 10, 10, NOW)).toBe(0);
-  });
-
-  it('returns 0 for prediction <= 0', () => {
-    expect(computeComeback([makeSeason(2020, 300)], 0, null, 10, 10, NOW)).toBe(0);
-  });
-
-  it('returns 0 without recovery evidence', () => {
-    // peak=500, prediction=100, ratio=5, gap=(4)*5=20 BUT trajectory=0 and form=0
-    expect(computeComeback([makeSeason(2020, 500)], 100, null, 0, 0, NOW)).toBe(0);
-  });
-
-  it('returns 0 with low trajectory and form', () => {
-    expect(computeComeback([makeSeason(2020, 500)], 100, null, 5, 5, NOW)).toBe(0);
-  });
-
-  it('computes gap when trajectory provides recovery evidence', () => {
-    // peak=500, prediction=100, ratio=5, gap=(5-1)*5=20, trajectory=10 > 5 → recovery yes
-    expect(computeComeback([makeSeason(2020, 500)], 100, null, 10, 0, NOW)).toBe(20);
-  });
-
-  it('computes gap when form provides recovery evidence', () => {
-    // peak=300, prediction=100, ratio=3, gap=(3-1)*5=10, form=8 > 5 → recovery yes
-    expect(computeComeback([makeSeason(2020, 300)], 100, null, 0, 8, NOW)).toBe(10);
-  });
-
-  it('clamps at 20', () => {
-    expect(computeComeback([makeSeason(2020, 1000)], 50, null, 10, 10, NOW)).toBe(20);
-  });
-});
-
-// ── Signal 4: Route Fit ─────────────────────────────────────────────
+// ── Signal 3: Route Fit ─────────────────────────────────────────────
 
 describe('computeRouteFit', () => {
   const flatRace: ProfileSummary = {
@@ -279,7 +230,7 @@ describe('computeRouteFit', () => {
   it('scores high for sprinter on flat course', () => {
     const sprinter = cat(0, 5, 0, 95);
     const score = computeRouteFit(sprinter, flatRace);
-    expect(score).toBeGreaterThan(8);
+    expect(score).toBeGreaterThan(10);
   });
 
   it('scores low for climber on flat course', () => {
@@ -289,17 +240,17 @@ describe('computeRouteFit', () => {
   });
 });
 
-// ── Signal 5: Variance ──────────────────────────────────────────────
+// ── Signal 4: Variance ──────────────────────────────────────────────
 
 describe('computeVariance', () => {
-  it('returns 7.5 for fewer than 2 seasons of data', () => {
-    expect(computeVariance([])).toBe(7.5);
-    expect(computeVariance([makePerf('r', 2024, 10, 100)])).toBe(7.5);
+  it('returns 10 for fewer than 2 seasons of data', () => {
+    expect(computeVariance([])).toBe(10);
+    expect(computeVariance([makePerf('r', 2024, 10, 100)])).toBe(10);
   });
 
-  it('returns 7.5 when only 1 season has non-zero avg', () => {
+  it('returns 10 when only 1 season has non-zero avg', () => {
     const perfs = [makePerf('r1', 2024, 10, 100), makePerf('r2', 2023, 200, 0)];
-    expect(computeVariance(perfs)).toBe(7.5);
+    expect(computeVariance(perfs)).toBe(10);
   });
 
   it('returns 0 for identical per-season averages', () => {
@@ -313,21 +264,20 @@ describe('computeVariance', () => {
   });
 
   it('computes CV-based score on per-season averages', () => {
-    // 2024: avg(50,150)=100, 2023: avg(20,80)=50. Mean=75, SD=25, CV=0.333, score=5.0
+    // 2024: avg(50,150)=100, 2023: avg(20,80)=50. Mean=75, SD=25, CV=0.333, score=6.67
     const perfs = [
       makePerf('r1', 2024, 10, 50),
       makePerf('r2', 2024, 30, 150),
       makePerf('r3', 2023, 200, 20),
       makePerf('r4', 2023, 250, 80),
     ];
-    expect(computeVariance(perfs)).toBeCloseTo(5.0, 1);
+    expect(computeVariance(perfs)).toBeCloseTo(6.67, 0);
   });
 
   it('normalizes by races per season', () => {
-    // Season A: 1 race scoring 200 → avg 200
-    // Season B: 4 races scoring 50 each → avg 50
-    // Old variance on totals: [200, 200] → CV=0 (same total!)
-    // New variance on avgs: [200, 50] → mean=125, SD=75, CV=0.6 → score=9
+    // Season A: 1 race scoring 200 -> avg 200
+    // Season B: 4 races scoring 50 each -> avg 50
+    // Variance on avgs: [200, 50] -> mean=125, SD=75, CV=0.6 -> score=12
     const perfs = [
       makePerf('r1', 2024, 10, 200),
       makePerf('r2', 2023, 100, 50),
@@ -335,13 +285,13 @@ describe('computeVariance', () => {
       makePerf('r4', 2023, 200, 50),
       makePerf('r5', 2023, 250, 50),
     ];
-    expect(computeVariance(perfs)).toBeCloseTo(9.0, 0);
+    expect(computeVariance(perfs)).toBeCloseTo(12.0, 0);
   });
 
-  it('clamps at 15', () => {
-    // Extreme: avg 500 vs avg 10. Mean=255, SD=245, CV≈0.96 → score≈14.4
+  it('clamps at 20', () => {
+    // Extreme: avg 500 vs avg 10. Mean=255, SD=245, CV~0.96 -> score~19.2
     const perfs = [makePerf('r1', 2024, 10, 500), makePerf('r2', 2023, 200, 10)];
-    expect(computeVariance(perfs)).toBeLessThanOrEqual(15);
+    expect(computeVariance(perfs)).toBeLessThanOrEqual(20);
   });
 });
 
@@ -349,17 +299,17 @@ describe('computeVariance', () => {
 
 describe('computeBpiIndex', () => {
   it('sums signals and rounds', () => {
-    const signals = { trajectory: 10.3, form: 5.7, comeback: 8, routeFit: 3, variance: 7 };
+    const signals = { trajectory: 12.3, form: 7.7, routeFit: 4, variance: 10 };
     expect(computeBpiIndex(signals)).toBe(34);
   });
 
   it('clamps at 100', () => {
-    const signals = { trajectory: 25, form: 25, comeback: 20, routeFit: 15, variance: 15 };
+    const signals = { trajectory: 30, form: 30, routeFit: 20, variance: 20 };
     expect(computeBpiIndex(signals)).toBe(100);
   });
 
   it('clamps at 0', () => {
-    const signals = { trajectory: 0, form: 0, comeback: 0, routeFit: 0, variance: 0 };
+    const signals = { trajectory: 0, form: 0, routeFit: 0, variance: 0 };
     expect(computeBpiIndex(signals)).toBe(0);
   });
 });
@@ -367,7 +317,7 @@ describe('computeBpiIndex', () => {
 // ── Upside P80 ──────────────────────────────────────────────────────
 
 describe('computeUpsideP80', () => {
-  it('returns prediction × 1.8 for < 3 seasons', () => {
+  it('returns prediction x 1.8 for < 3 seasons', () => {
     const seasons = [makeSeason(2024, 100), makeSeason(2023, 80)];
     expect(computeUpsideP80(seasons, 50)).toBe(90); // 50 * 1.8 = 90
   });
@@ -414,7 +364,7 @@ describe('evaluateFlags', () => {
     categoryScores: cat(25, 25, 25, 25),
   };
 
-  const neutralSignals = { trajectory: 0, form: 0, comeback: 0, routeFit: 0, variance: 7.5 };
+  const neutralSignals = { trajectory: 0, form: 0, routeFit: 0, variance: 10 };
 
   describe('EMERGING_TALENT', () => {
     it('triggers for young rider with steep slope', () => {
@@ -452,13 +402,13 @@ describe('evaluateFlags', () => {
   });
 
   describe('HOT_STREAK', () => {
-    it('triggers when form signal > 12.5', () => {
-      const signals = { ...neutralSignals, form: 15 };
+    it('triggers when form signal > 15', () => {
+      const signals = { ...neutralSignals, form: 18 };
       expect(evaluateFlags(baseInput, signals)).toContain(BreakoutFlag.HotStreak);
     });
 
-    it('does not trigger when form signal <= 12.5', () => {
-      const signals = { ...neutralSignals, form: 10 };
+    it('does not trigger when form signal <= 15', () => {
+      const signals = { ...neutralSignals, form: 12 };
       expect(evaluateFlags(baseInput, signals)).not.toContain(BreakoutFlag.HotStreak);
     });
   });
@@ -494,18 +444,6 @@ describe('evaluateFlags', () => {
       };
       // ptsPerHillio = 15/50 = 0.3 > 0.1, but prediction < 20
       expect(evaluateFlags(input, neutralSignals)).not.toContain(BreakoutFlag.DeepValue);
-    });
-  });
-
-  describe('COMEBACK', () => {
-    it('triggers when comeback signal > 10', () => {
-      const signals = { ...neutralSignals, comeback: 15 };
-      expect(evaluateFlags(baseInput, signals)).toContain(BreakoutFlag.Comeback);
-    });
-
-    it('does not trigger when comeback signal <= 10', () => {
-      const signals = { ...neutralSignals, comeback: 8 };
-      expect(evaluateFlags(baseInput, signals)).not.toContain(BreakoutFlag.Comeback);
     });
   });
 
@@ -562,7 +500,7 @@ describe('evaluateFlags', () => {
   });
 
   describe('RACE_SPECIALIST', () => {
-    it('triggers when median history > 1.15× prediction', () => {
+    it('triggers when median history > 1.15x prediction', () => {
       const input: ComputeBreakoutInput = {
         ...baseInput,
         prediction: 100,
@@ -611,7 +549,6 @@ describe('computeBreakout', () => {
     expect(Array.isArray(result.flags)).toBe(true);
     expect(result.signals).toHaveProperty('trajectory');
     expect(result.signals).toHaveProperty('form');
-    expect(result.signals).toHaveProperty('comeback');
     expect(result.signals).toHaveProperty('routeFit');
     expect(result.signals).toHaveProperty('variance');
   });
@@ -628,7 +565,7 @@ describe('computeBreakout', () => {
     };
 
     const result = computeBreakout(input);
-    expect(result.index).toBe(8); // only variance 7.5 → rounds to 8
+    expect(result.index).toBe(10); // only variance default 10 -> rounds to 10
     expect(result.upsideP80).toBe(0);
     expect(result.flags).toEqual([]);
   });
@@ -649,7 +586,7 @@ describe('computeBreakout', () => {
     };
 
     const result = computeBreakout(input);
-    expect(result.index).toBe(8); // only variance default 7.5
+    expect(result.index).toBe(10); // only variance default 10
     expect(result.upsideP80).toBe(0);
   });
 });
@@ -666,7 +603,7 @@ describe('computeP75PtsPerHillio', () => {
   });
 
   it('computes P75 for sorted values', () => {
-    // sorted: [1, 2, 3, 4]. P75 index = floor(4*0.75) = 3 → value = 4
+    // sorted: [1, 2, 3, 4]. P75 index = floor(4*0.75) = 3 -> value = 4
     const riders = [
       { pointsPerHillio: 1 },
       { pointsPerHillio: 2 },
@@ -677,13 +614,13 @@ describe('computeP75PtsPerHillio', () => {
   });
 
   it('computes P75 for odd count', () => {
-    // sorted: [1, 3, 5]. P75 index = floor(3*0.75) = 2 → value = 5
+    // sorted: [1, 3, 5]. P75 index = floor(3*0.75) = 2 -> value = 5
     const riders = [{ pointsPerHillio: 1 }, { pointsPerHillio: 3 }, { pointsPerHillio: 5 }];
     expect(computeP75PtsPerHillio(riders)).toBe(5);
   });
 
   it('filters out null and zero values', () => {
-    // valid: [5, 10]. P75 index = floor(2*0.75) = 1 → value = 10
+    // valid: [5, 10]. P75 index = floor(2*0.75) = 1 -> value = 10
     const riders = [
       { pointsPerHillio: null },
       { pointsPerHillio: 0 },

--- a/apps/api/src/domain/breakout/breakout.service.ts
+++ b/apps/api/src/domain/breakout/breakout.service.ts
@@ -10,7 +10,6 @@ import type { ComputeBreakoutInput, CoreCategoryScores, RacePerformance } from '
 const EMERGING_TALENT: BreakoutFlag = 'EMERGING_TALENT' as BreakoutFlag;
 const HOT_STREAK: BreakoutFlag = 'HOT_STREAK' as BreakoutFlag;
 const DEEP_VALUE: BreakoutFlag = 'DEEP_VALUE' as BreakoutFlag;
-const COMEBACK_FLAG: BreakoutFlag = 'COMEBACK' as BreakoutFlag;
 const SPRINT_OPPORTUNITY: BreakoutFlag = 'SPRINT_OPPORTUNITY' as BreakoutFlag;
 const BREAKAWAY_HUNTER: BreakoutFlag = 'BREAKAWAY_HUNTER' as BreakoutFlag;
 const RACE_SPECIALIST: BreakoutFlag = 'RACE_SPECIALIST' as BreakoutFlag;
@@ -18,7 +17,7 @@ const RACE_SPECIALIST: BreakoutFlag = 'RACE_SPECIALIST' as BreakoutFlag;
 const DEFAULT_AGE = 28;
 const FORM_WINDOW_DAYS = 90;
 
-// ── Helpers ───────────────────────────────��──────────────────────────
+// ── Helpers ─────────────────────────────────────────────────────────
 
 export function computeAge(birthDate: Date | null, currentDate: Date = new Date()): number {
   if (!birthDate) return DEFAULT_AGE;
@@ -44,7 +43,7 @@ export function computeRawSlope(seasons: readonly SeasonBreakdown[]): number {
   return (n * sumXY - sumX * sumY) / denom;
 }
 
-// ── Signal 1: Trajectory (0-25) ─────────────────────────────────────
+// ── Signal 1: Trajectory (0-30) ─────────────────────────────────────
 // Uses only completed seasons (excludes current year) to avoid
 // partial-season depression of the slope.
 
@@ -66,10 +65,10 @@ export function computeTrajectory(
   else if (age <= 31) ageFactor = 0.5;
   else ageFactor = 0.2;
 
-  return Math.min(25, Math.max(0, slope * ageFactor));
+  return Math.min(30, Math.max(0, slope * ageFactor));
 }
 
-// ── Signal 2: Form (0-25) ───────────────────────────────────────────
+// ── Signal 2: Form (0-30) ───────────────────────────────────────────
 // Rolling 90-day window: compares recent pts/race vs career pts/race.
 // Replaces the broken calendar-year Recency signal.
 
@@ -90,35 +89,10 @@ export function computeForm(
   if (allAvg === 0) return 0;
 
   const ratio = recentAvg / allAvg;
-  return Math.min(25, Math.max(0, (ratio - 1) * 25));
+  return Math.min(30, Math.max(0, (ratio - 1) * 30));
 }
 
-// ── Signal 3: Comeback (0-20) ─────────────────────────────��─────────
-// Ceiling gap (peak vs prediction) gated by recovery evidence.
-// Only scores if trajectory or form show the rider is bouncing back.
-
-export function computeComeback(
-  seasons: readonly SeasonBreakdown[],
-  prediction: number,
-  birthDate: Date | null,
-  trajectoryScore: number,
-  formScore: number,
-  currentDate: Date = new Date(),
-): number {
-  const age = computeAge(birthDate, currentDate);
-  if (age > 33) return 0;
-  if (seasons.length === 0) return 0;
-  if (prediction <= 0) return 0;
-
-  const peak = Math.max(...seasons.map((s) => s.total));
-  const ratio = peak / prediction;
-  const gapScore = Math.min(20, Math.max(0, (ratio - 1) * 5));
-
-  const hasRecoveryEvidence = trajectoryScore > 5 || formScore > 5;
-  return hasRecoveryEvidence ? gapScore : 0;
-}
-
-// ── Signal 4: Route Fit (0-15) ──────────────────────────���───────────
+// ── Signal 3: Route Fit (0-20) ──────────────────────────────────────
 
 export function computeRouteFit(
   categoryScores: CoreCategoryScores | null,
@@ -161,10 +135,10 @@ export function computeRouteFit(
     riderProfile.mountain * raceProfile.mountain +
     riderProfile.sprint * raceProfile.sprint;
 
-  return Math.min(15, Math.max(0, dot * 15));
+  return Math.min(20, Math.max(0, dot * 20));
 }
 
-// ── Signal 5: Variance (0-15) ──────────────────────────────���────────
+// ── Signal 4: Variance (0-20) ───────────────────────────────────────
 // Normalized by pts/race per season to avoid penalizing riders
 // with fewer races in a given year.
 
@@ -180,7 +154,7 @@ export function computeVariance(racePerformances: readonly RacePerformance[]): n
     .map((totals) => totals.reduce((a, b) => a + b, 0) / totals.length)
     .filter((avg) => avg > 0);
 
-  if (seasonAverages.length < 2) return 7.5;
+  if (seasonAverages.length < 2) return 10;
 
   const mean = seasonAverages.reduce((a, b) => a + b, 0) / seasonAverages.length;
   if (mean === 0) return 0;
@@ -189,14 +163,13 @@ export function computeVariance(racePerformances: readonly RacePerformance[]): n
     seasonAverages.reduce((sum, v) => sum + (v - mean) ** 2, 0) / seasonAverages.length;
   const cv = Math.sqrt(variance) / mean;
 
-  return Math.min(15, Math.max(0, cv * 15));
+  return Math.min(20, Math.max(0, cv * 20));
 }
 
 // ── Composite Index (0-100) ─────────────────────────────────────────
 
 export function computeBpiIndex(signals: BreakoutSignals): number {
-  const raw =
-    signals.trajectory + signals.form + signals.comeback + signals.routeFit + signals.variance;
+  const raw = signals.trajectory + signals.form + signals.routeFit + signals.variance;
   return Math.min(100, Math.max(0, Math.round(raw)));
 }
 
@@ -260,8 +233,8 @@ export function evaluateFlags(
     if (slope > 30) flags.push(EMERGING_TALENT);
   }
 
-  // HOT_STREAK — strong recent form (form signal > 12.5 ≈ recent avg 1.5× career)
-  if (signals.form > 12.5) {
+  // HOT_STREAK — strong recent form (form signal > 15 ≈ recent avg 1.5x career)
+  if (signals.form > 15) {
     flags.push(HOT_STREAK);
   }
 
@@ -269,11 +242,6 @@ export function evaluateFlags(
   const ptsPerHillio = input.priceHillios > 0 ? input.prediction / input.priceHillios : 0;
   if (input.priceHillios <= 100 && input.prediction >= 20 && ptsPerHillio > input.p75PtsPerHillio) {
     flags.push(DEEP_VALUE);
-  }
-
-  // COMEBACK — significant ceiling gap with recovery evidence
-  if (signals.comeback > 10) {
-    flags.push(COMEBACK_FLAG);
   }
 
   // SPRINT_OPPORTUNITY
@@ -325,13 +293,6 @@ export function computeBreakout(input: ComputeBreakoutInput): BreakoutResult {
   const signals: BreakoutSignals = {
     trajectory: trajectoryScore,
     form: formScore,
-    comeback: computeComeback(
-      input.seasonBreakdown,
-      input.prediction,
-      input.birthDate,
-      trajectoryScore,
-      formScore,
-    ),
     routeFit: computeRouteFit(input.categoryScores, input.profileSummary),
     variance: computeVariance(input.racePerformances),
   };

--- a/apps/api/src/domain/breakout/index.ts
+++ b/apps/api/src/domain/breakout/index.ts
@@ -1,7 +1,6 @@
 export {
   computeTrajectory,
   computeForm,
-  computeComeback,
   computeRouteFit,
   computeVariance,
   computeBpiIndex,

--- a/apps/web/src/features/rider-list/components/bpi-badge.tsx
+++ b/apps/web/src/features/rider-list/components/bpi-badge.tsx
@@ -59,11 +59,6 @@ const FLAG_CONFIG: Record<string, { label: string; colorClass: string; descripti
     colorClass: 'bg-green-500/15 text-green-600 dark:text-green-400 border-green-500/40',
     description: 'Top-quartile pts/hillio at low price with meaningful prediction',
   },
-  COMEBACK: {
-    label: 'COMEBACK',
-    colorClass: 'bg-primary/15 text-primary border-primary/40',
-    description: 'Historical peak far exceeds prediction with recovery signs',
-  },
   SPRINT_OPPORTUNITY: {
     label: 'SPRINT',
     colorClass: 'bg-tertiary/15 text-tertiary border-tertiary/40',

--- a/apps/web/src/features/rider-list/components/breakout-detail-panel.tsx
+++ b/apps/web/src/features/rider-list/components/breakout-detail-panel.tsx
@@ -17,31 +17,25 @@ const SIGNAL_CONFIGS: SignalConfig[] = [
   {
     key: 'trajectory',
     label: 'Trajectory',
-    max: 25,
+    max: 30,
     description: 'Career trend direction — rising, stable, or declining',
   },
   {
     key: 'form',
     label: 'Form',
-    max: 25,
+    max: 30,
     description: 'Recent 90-day performance vs career average — current hot streak',
-  },
-  {
-    key: 'comeback',
-    label: 'Comeback',
-    max: 20,
-    description: 'Gap to historical peak with evidence of recovery',
   },
   {
     key: 'routeFit',
     label: 'Route Fit',
-    max: 15,
+    max: 20,
     description: 'How well rider profile matches the race parcours',
   },
   {
     key: 'variance',
     label: 'Variance',
-    max: 15,
+    max: 20,
     description: 'Score volatility — high variance means bigger boom-or-bust potential',
   },
 ];
@@ -50,7 +44,6 @@ const FLAG_DESCRIPTIONS: Record<string, string> = {
   EMERGING_TALENT: 'Young rider with steep upward career trajectory',
   HOT_STREAK: 'Strong recent form — last 90 days well above career average',
   DEEP_VALUE: 'Top-quartile efficiency at low price with meaningful prediction',
-  COMEBACK: 'Historical peak far exceeds prediction with recovery signs',
   SPRINT_OPPORTUNITY: 'Sprint profile on a flat-friendly course',
   BREAKAWAY_HUNTER: 'Mountain points on a budget — breakaway potential',
   RACE_SPECIALIST: 'Historically outperforms predictions in this race',

--- a/apps/web/src/features/rider-list/components/rider-table.tsx
+++ b/apps/web/src/features/rider-list/components/rider-table.tsx
@@ -192,8 +192,8 @@ function createColumns(
             </span>
           </TooltipTrigger>
           <TooltipContent className="max-w-[200px]">
-            Breakout Potential Index (0-100). Composite of trajectory, form, comeback, route fit and
-            variance signals.
+            Breakout Potential Index (0-100). Composite of trajectory, form, route fit and variance
+            signals.
           </TooltipContent>
         </Tooltip>
       ),

--- a/apps/web/tests/e2e/specs/breakout.spec.ts
+++ b/apps/web/tests/e2e/specs/breakout.spec.ts
@@ -125,7 +125,6 @@ test.describe('Breakout Potential Index', () => {
       // All 5 signal labels should be present
       await expect(dashboardPage.riderTable.getByText('Trajectory', { exact: true })).toBeVisible();
       await expect(dashboardPage.riderTable.getByText('Form', { exact: true })).toBeVisible();
-      await expect(dashboardPage.riderTable.getByText('Comeback', { exact: true })).toBeVisible();
       await expect(dashboardPage.riderTable.getByText('Route Fit', { exact: true })).toBeVisible();
       await expect(dashboardPage.riderTable.getByText('Variance', { exact: true })).toBeVisible();
     });

--- a/kitty-specs/015-breakout-potential-index/contracts/analyze-response.schema.ts
+++ b/kitty-specs/015-breakout-potential-index/contracts/analyze-response.schema.ts
@@ -11,22 +11,19 @@ export enum BreakoutFlag {
   EmergingTalent = 'EMERGING_TALENT',
   HotStreak = 'HOT_STREAK',
   DeepValue = 'DEEP_VALUE',
-  Comeback = 'COMEBACK',
   SprintOpportunity = 'SPRINT_OPPORTUNITY',
   BreakawayHunter = 'BREAKAWAY_HUNTER',
   RaceSpecialist = 'RACE_SPECIALIST',
 }
 
 export interface BreakoutSignals {
-  /** Career trajectory slope adjusted by age factor (0-25) */
+  /** Career trajectory slope adjusted by age factor (0-30) */
   trajectory: number;
-  /** 90-day rolling form vs career average pts/race (0-25) */
+  /** 90-day rolling form vs career average pts/race (0-30) */
   form: number;
-  /** Ceiling gap gated by recovery evidence (0-20) */
-  comeback: number;
-  /** Rider category profile × race route profile fit (0-15) */
+  /** Rider category profile × race route profile fit (0-20) */
   routeFit: number;
-  /** Season-to-season variance normalized by pts/race (0-15) */
+  /** Season-to-season variance normalized by pts/race (0-20) */
   variance: number;
 }
 
@@ -77,11 +74,10 @@ export const exampleRider = {
     upsideP80: 215,
     flags: ['EMERGING_TALENT', 'HOT_STREAK'],
     signals: {
-      trajectory: 22,
-      form: 20,
-      comeback: 14,
-      routeFit: 8,
-      variance: 10,
+      trajectory: 26,
+      form: 24,
+      routeFit: 10,
+      variance: 14,
     },
   },
 };

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -49,7 +49,6 @@ export enum BreakoutFlag {
   EmergingTalent = 'EMERGING_TALENT',
   HotStreak = 'HOT_STREAK',
   DeepValue = 'DEEP_VALUE',
-  Comeback = 'COMEBACK',
   SprintOpportunity = 'SPRINT_OPPORTUNITY',
   BreakawayHunter = 'BREAKAWAY_HUNTER',
   RaceSpecialist = 'RACE_SPECIALIST',
@@ -58,7 +57,6 @@ export enum BreakoutFlag {
 export interface BreakoutSignals {
   readonly trajectory: number;
   readonly form: number;
-  readonly comeback: number;
   readonly routeFit: number;
   readonly variance: number;
 }


### PR DESCRIPTION
## Summary
- Remove the `comeback` signal from BPI — it compared full-season peak totals against single-race predictions (apples vs oranges) and penalized riders with incomplete 2026 seasons (e.g. Ivan Romeo: 191.8 full 2025 vs 76.7 partial 2026)
- Redistribute its 20 points across remaining signals: Trajectory 25→30, Form 25→30, Route Fit 15→20, Variance 15→20 (total still 100)
- Remove `COMEBACK` flag, enum value, and all frontend references (detail panel, badge, tooltip)

## Test plan
- [x] All 513 unit tests pass
- [x] Lint clean
- [x] Typecheck clean
- [ ] Verify BPI scores no longer show comeback signal bar in UI
- [ ] Verify COMEBACK flag chip no longer appears on any rider

🤖 Generated with [Claude Code](https://claude.com/claude-code)