### PR TITLE
fix: match GMV price list by correct year

### DIFF
--- a/apps/api/src/domain/gmv/fuzzy-match.spec.ts
+++ b/apps/api/src/domain/gmv/fuzzy-match.spec.ts
@@ -1,0 +1,50 @@
+import { fuzzyMatchGmvPost } from './fuzzy-match';
+import type { GmvPost } from './gmv-post';
+
+function post(id: number, title: string): GmvPost {
+  return { id, title, url: `https://gmv.com/${id}`, date: '2024-01-01' };
+}
+
+describe('fuzzyMatchGmvPost', () => {
+  it('matches the correct year when multiple years exist', () => {
+    const posts = [
+      post(1, 'La Vuelta 2025 – Precios'),
+      post(2, 'La Vuelta 2024 – Precios'),
+      post(3, 'La Vuelta 2023 – Precios'),
+    ];
+
+    const result = fuzzyMatchGmvPost('vuelta-a-espana', 'Vuelta A Espana', 2024, posts);
+
+    expect(result).not.toBeNull();
+    expect(result!.post.id).toBe(2);
+  });
+
+  it('skips posts that contain a different year', () => {
+    const posts = [post(1, 'La Vuelta 2025 – Precios')];
+
+    const result = fuzzyMatchGmvPost('vuelta-a-espana', 'Vuelta A Espana', 2024, posts);
+
+    expect(result).toBeNull();
+  });
+
+  it('matches posts with no year in the title', () => {
+    const posts = [post(1, 'La Vuelta – Precios')];
+
+    const result = fuzzyMatchGmvPost('vuelta-a-espana', 'Vuelta A Espana', 2024, posts);
+
+    expect(result).not.toBeNull();
+    expect(result!.post.id).toBe(1);
+  });
+
+  it('matches using aliases (Giro)', () => {
+    const posts = [
+      post(1, 'Giro de Italia 2024 – Precios'),
+      post(2, 'Tour de Francia 2024 – Precios'),
+    ];
+
+    const result = fuzzyMatchGmvPost('giro-d-italia', 'Giro D Italia', 2024, posts);
+
+    expect(result).not.toBeNull();
+    expect(result!.post.id).toBe(1);
+  });
+});

--- a/apps/api/src/domain/gmv/fuzzy-match.ts
+++ b/apps/api/src/domain/gmv/fuzzy-match.ts
@@ -19,6 +19,7 @@ export function fuzzyMatchGmvPost(
 
   for (const term of searchTerms) {
     for (const post of posts) {
+      if (containsDifferentYear(post.title, year)) continue;
       const confidence = computeTokenOverlap(term, year, post.title);
       if (confidence >= CONFIDENCE_THRESHOLD && (!bestMatch || confidence > bestMatch.confidence)) {
         bestMatch = { post, confidence };
@@ -66,4 +67,11 @@ function normalize(text: string): string {
 
 function stripYear(text: string, year: number): string {
   return text.replace(String(year), '').trim();
+}
+
+/** Returns true if the text mentions a 4-digit year that is NOT the target year */
+function containsDifferentYear(text: string, targetYear: number): boolean {
+  const yearMatches = text.match(/\b(20\d{2})\b/g);
+  if (!yearMatches) return false;
+  return yearMatches.every((y) => Number(y) !== targetYear);
 }

--- a/apps/api/src/infrastructure/gmv/gmv-client.adapter.ts
+++ b/apps/api/src/infrastructure/gmv/gmv-client.adapter.ts
@@ -11,38 +11,51 @@ export class GmvClientAdapter {
 
   async fetchPostsFromApi(): Promise<GmvPost[]> {
     try {
-      const url = `${GMV_WP_API_URL}?categories=${GMV_CATEGORIES}&per_page=100&_fields=id,title,link,date`;
-      this.logger.debug(`Fetching GMV posts: ${url}`);
+      const allPosts: GmvPost[] = [];
+      let page = 1;
+      let totalPages = 1;
 
-      const response = await fetch(url, {
-        signal: AbortSignal.timeout(10_000),
-      });
+      do {
+        const url = `${GMV_WP_API_URL}?categories=${GMV_CATEGORIES}&per_page=100&page=${page}&_fields=id,title,link,date`;
+        this.logger.debug(`Fetching GMV posts page ${page}: ${url}`);
 
-      if (!response.ok) {
-        this.logger.error(`GMV API returned ${response.status}`);
-        return [];
-      }
+        const response = await fetch(url, {
+          signal: AbortSignal.timeout(10_000),
+        });
 
-      const rawPosts = (await response.json()) as Array<{
-        id: number;
-        title: { rendered: string };
-        link: string;
-        date: string;
-      }>;
+        if (!response.ok) {
+          this.logger.error(`GMV API returned ${response.status} on page ${page}`);
+          break;
+        }
 
-      const posts = rawPosts
-        .filter(
-          (p) => !EXCLUDED_TITLE_PATTERNS.some((pattern) => p.title.rendered.includes(pattern)),
-        )
-        .map((p) => ({
-          id: p.id,
-          title: this.decodeHtmlEntities(p.title.rendered),
-          url: p.link,
-          date: p.date,
-        }));
+        if (page === 1) {
+          totalPages = parseInt(response.headers.get('x-wp-totalpages') ?? '1', 10);
+        }
 
-      this.logger.debug(`Fetched ${posts.length} GMV price list posts`);
-      return posts;
+        const rawPosts = (await response.json()) as Array<{
+          id: number;
+          title: { rendered: string };
+          link: string;
+          date: string;
+        }>;
+
+        const posts = rawPosts
+          .filter(
+            (p) => !EXCLUDED_TITLE_PATTERNS.some((pattern) => p.title.rendered.includes(pattern)),
+          )
+          .map((p) => ({
+            id: p.id,
+            title: this.decodeHtmlEntities(p.title.rendered),
+            url: p.link,
+            date: p.date,
+          }));
+
+        allPosts.push(...posts);
+        page++;
+      } while (page <= totalPages);
+
+      this.logger.debug(`Fetched ${allPosts.length} GMV price list posts (${totalPages} pages)`);
+      return allPosts;
     } catch (error) {
       this.logger.warn(`GMV API unavailable: ${(error as Error).message}`);
       return [];


### PR DESCRIPTION
## Summary
- **Year filter in fuzzy match**: posts containing a different 4-digit year than the requested one are now skipped before scoring, preventing e.g. Vuelta 2025 from matching when Vuelta 2024 is selected
- **Full pagination of GMV API**: WordPress API returns 337 posts across 4 pages; previously only the first page (100 posts) was fetched, missing all pre-2025 races. Now paginates using `x-wp-totalpages` header
- Added unit tests for `fuzzyMatchGmvPost` covering year filtering and alias matching

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (434 tests)
- [x] New fuzzy-match unit tests cover year filtering edge cases
- [ ] Manual: select Vuelta 2024 in setup → should load correct price list with Roglic

🤖 Generated with [Claude Code](https://claude.com/claude-code)