### PR TITLE
ci: gate E2E tests behind quality and test workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,18 +1,59 @@
 name: E2E Tests
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ['Code Quality', 'Tests']
+    types: [completed]
+
+permissions:
+  actions: read
+  checks: write
+  statuses: write
 
 concurrency:
-  group: e2e-${{ github.ref }}
+  group: e2e-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
+  gate:
+    name: Check Prerequisites
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Verify all prerequisite workflows passed
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_sha;
+            const triggeringWorkflow = context.payload.workflow_run.name;
+            const requiredWorkflows = ['Code Quality', 'Tests'];
+            const otherWorkflow = requiredWorkflows.find(w => w !== triggeringWorkflow);
+
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: sha,
+            });
+
+            const otherRun = runs.workflow_runs.find(
+              r => r.name === otherWorkflow && r.conclusion === 'success'
+            );
+
+            if (otherRun) {
+              core.info(`Both "${triggeringWorkflow}" and "${otherWorkflow}" passed for ${sha}`);
+              core.setOutput('should_run', 'true');
+            } else {
+              core.info(`"${otherWorkflow}" has not passed yet for ${sha} — skipping`);
+              core.setOutput('should_run', 'false');
+            }
+
   e2e:
     name: Playwright
+    needs: gate
+    if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -37,6 +78,8 @@ jobs:
       SKIP_EXTERNAL: 'true'
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- E2E workflow now triggers via `workflow_run` instead of direct `pull_request`/`push`, so it only runs **after both Code Quality and Tests workflows pass**
- A lightweight gate job uses the GitHub API to verify both prerequisite workflows succeeded for the same commit SHA before starting the expensive Playwright suite
- Saves CI minutes by not spinning up Postgres + build + Playwright when lint/types/unit tests are still failing

## How it works

1. Either "Code Quality" or "Tests" completes successfully -> `workflow_run` fires
2. Gate job checks if the **other** workflow also passed for the same SHA
3. If both passed -> Playwright runs; otherwise -> skipped (the other workflow's completion will re-trigger and succeed)

## Notes

- Branch ruleset may need the E2E required check re-added if the check name changes under the `workflow_run` context
- The 3-file structure is preserved: `quality.yml`, `test.yml`, `e2e.yml` remain independent

## Test plan

- [ ] Push a commit with a lint error -> verify E2E never starts
- [ ] Push a clean commit -> verify E2E runs after both Quality and Tests pass
- [ ] Verify the E2E check appears in the PR status checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)