### PR TITLE
fix: fit setup tab within viewport on 1080p desktop

### DIFF
--- a/apps/web/src/features/rider-list/components/rider-input.tsx
+++ b/apps/web/src/features/rider-list/components/rider-input.tsx
@@ -132,18 +132,18 @@ export function RiderInput({
   };
 
   return (
-    <div className="flex flex-col gap-6">
-      <header className="mb-2">
+    <div className="flex flex-col gap-3 lg:min-h-0 lg:flex-1">
+      <header className="flex-shrink-0">
         <span className="text-secondary font-mono text-xs tracking-widest uppercase mb-1 flex items-center gap-1.5">
           <Settings className="h-3.5 w-3.5" />
           Analysis Engine
         </span>
-        <h1 className="text-3xl font-headline font-extrabold text-on-surface tracking-tight">
+        <h1 className="text-2xl lg:text-xl font-headline font-extrabold text-on-surface tracking-tight">
           Roster Setup
         </h1>
       </header>
 
-      <div className="bg-surface-container-low rounded-sm p-4 md:p-8 flex flex-col gap-5 md:gap-6 shadow-xl border border-outline-variant/15">
+      <div className="bg-surface-container-low rounded-sm p-4 md:p-5 flex flex-col gap-4 shadow-xl border border-outline-variant/15 lg:overflow-y-auto lg:min-h-0 lg:flex-1">
         {/* Race Selector */}
         <div className="flex flex-col gap-2">
           <label className="text-xs font-body uppercase tracking-wider text-on-primary-container font-semibold">
@@ -255,7 +255,7 @@ export function RiderInput({
           )}
         </div>
 
-        <div className="h-px bg-outline-variant/10 my-2" />
+        <div className="h-px bg-outline-variant/10" />
 
         {/* Manual Rider Input */}
         <div className="flex flex-col gap-2">
@@ -271,7 +271,7 @@ export function RiderInput({
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder={`Tadej Pogacar, UAD, 500\nJonas Vingegaard, TVL, 480`}
-            rows={8}
+            rows={3}
             className="font-mono text-sm"
           />
           <div
@@ -313,29 +313,29 @@ export function RiderInput({
             />
           </div>
         </div>
-
-        {/* Analyze CTA */}
-        <Button
-          data-testid="setup-analyze-btn"
-          variant="cta"
-          size="lg"
-          onClick={handleSubmit}
-          disabled={parsedRiders.length === 0 || isLoading}
-          className="mt-4 w-full py-4"
-        >
-          {isLoading ? (
-            <>
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Analyzing...
-            </>
-          ) : (
-            <>
-              <BarChart3 className="h-4 w-4" />
-              Analyze Riders
-            </>
-          )}
-        </Button>
       </div>
+
+      {/* Analyze CTA — outside card so it's always visible */}
+      <Button
+        data-testid="setup-analyze-btn"
+        variant="cta"
+        size="lg"
+        onClick={handleSubmit}
+        disabled={parsedRiders.length === 0 || isLoading}
+        className="w-full py-3 flex-shrink-0"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Analyzing...
+          </>
+        ) : (
+          <>
+            <BarChart3 className="h-4 w-4" />
+            Analyze Riders
+          </>
+        )}
+      </Button>
     </div>
   );
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -51,11 +51,8 @@ function RootLayout() {
             <div className="flex justify-between items-center px-4 md:px-5 lg:px-8 xl:px-12 h-14 md:h-16">
               <div className="flex items-center gap-2 md:gap-3 min-w-0">
                 <img src="/logo.svg" alt="" className="h-7 w-7 md:h-8 md:w-8 flex-shrink-0" />
-                <span className="text-base md:text-xl font-black tracking-tighter text-on-surface uppercase italic font-headline truncate">
+                <span className="text-base md:text-xl font-black tracking-tighter text-on-surface uppercase italic font-headline">
                   CYCLING FANTASY OPTIMIZER
-                </span>
-                <span className="hidden md:inline-block text-[9px] font-mono text-outline/50 uppercase tracking-widest ml-2 border border-outline-variant/15 px-1.5 py-0.5 rounded-sm">
-                  v2
                 </span>
               </div>
               <div className="flex items-center gap-4">

--- a/apps/web/src/routes/tabs/-setup-tab.tsx
+++ b/apps/web/src/routes/tabs/-setup-tab.tsx
@@ -73,9 +73,9 @@ export function SetupTab({
   return (
     <div
       data-testid="tab-content-setup"
-      className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-12 pt-2"
+      className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 pt-2 lg:h-[calc(100dvh-10rem)] lg:max-h-[calc(100dvh-10rem)]"
     >
-      <div className="lg:col-span-5 flex flex-col gap-6">
+      <div className="lg:col-span-5 flex flex-col lg:min-h-0">
         <RiderInput
           onAnalyze={onAnalyze}
           isLoading={isLoading}
@@ -98,7 +98,7 @@ export function SetupTab({
         />
       </div>
 
-      <div className="lg:col-span-7 flex flex-col">
+      <div className="lg:col-span-7 flex flex-col lg:min-h-0">
         <div className="flex justify-between items-end mb-4 px-2">
           <div className="flex flex-col">
             <span className="text-outline font-mono text-xs uppercase tracking-tight">
@@ -118,7 +118,7 @@ export function SetupTab({
 
         {error ? (
           /* Error state */
-          <div className="flex-1 min-h-[500px] rounded-sm bg-error-container/[0.06] border border-error/20 flex flex-col items-center justify-center p-12 relative overflow-hidden animate-fade-in">
+          <div className="flex-1 rounded-sm bg-error-container/[0.06] border border-error/20 flex flex-col items-center justify-center p-8 relative overflow-hidden animate-fade-in">
             <div
               className="absolute inset-0 opacity-[0.03] pointer-events-none"
               style={{
@@ -167,7 +167,7 @@ export function SetupTab({
             </div>
           </div>
         ) : isLoading ? (
-          <div className="flex-1 min-h-[500px] flex flex-col gap-4">
+          <div className="flex-1 flex flex-col gap-4">
             <div className="flex items-center gap-3 px-1">
               <LoadingSpinner />
               <span className="text-sm text-on-surface-variant">Analyzing riders...</span>
@@ -176,7 +176,7 @@ export function SetupTab({
           </div>
         ) : hasResult ? (
           /* Analysis complete — show summary */
-          <div className="hidden lg:flex flex-1 min-h-[500px] rounded-sm bg-surface-container-low/30 border border-secondary/20 flex-col items-center justify-center p-8 md:p-12 relative overflow-hidden">
+          <div className="hidden lg:flex flex-1 rounded-sm bg-surface-container-low/30 border border-secondary/20 flex-col items-center justify-center p-6 relative overflow-hidden">
             <div className="absolute bottom-0 left-0 right-0 h-32 bg-gradient-to-t from-secondary/[0.04] to-transparent pointer-events-none" />
 
             <div className="relative z-10 flex flex-col items-center text-center max-w-md animate-fade-in">
@@ -237,7 +237,7 @@ export function SetupTab({
           </div>
         ) : (
           /* Idle state — awaiting input */
-          <div className="hidden lg:flex flex-1 min-h-[500px] rounded-sm bg-surface-container-low/30 border border-dashed border-outline-variant/20 flex-col items-center justify-center p-8 md:p-12 relative overflow-hidden">
+          <div className="hidden lg:flex flex-1 rounded-sm bg-surface-container-low/30 border border-dashed border-outline-variant/20 flex-col items-center justify-center p-6 relative overflow-hidden">
             <div className="absolute inset-0 flex justify-center pointer-events-none">
               <div className="w-px h-full bg-gradient-to-b from-transparent via-outline-variant/10 to-transparent" />
             </div>
@@ -262,7 +262,7 @@ export function SetupTab({
           </div>
         )}
 
-        <div className="mt-4 md:mt-6 bg-surface-container-high/40 p-3 md:p-5 rounded-sm border border-outline-variant/10 animate-fade-in">
+        <div className="mt-3 bg-surface-container-high/40 p-3 md:p-4 rounded-sm border border-outline-variant/10 animate-fade-in">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-0 md:flex md:justify-between md:items-center">
             <div className="flex flex-col">
               <span className="text-[10px] md:text-xs text-outline uppercase font-mono tracking-tighter">


### PR DESCRIPTION
## Summary
- Constrain setup grid to viewport height on desktop (`lg:h-[calc(100dvh-10rem)]`)
- Move Analyze CTA button outside scrollable card so it's always visible at the bottom
- Compact form layout: reduced padding, gaps, and textarea rows
- Remove fixed `min-h-[500px]` from preview panels — use `flex-1` instead
- Remove v2 badge and `truncate` from navbar title to prevent text clipping

## Test plan
- [ ] Verify setup tab fits within viewport on 1080p (no vertical scroll needed)
- [ ] Verify Analyze button is always visible without scrolling
- [ ] Verify navbar title "CYCLING FANTASY OPTIMIZER" displays fully without clipping
- [ ] Verify form card scrolls internally when race profile summary is loaded
- [ ] Verify mobile layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)