### PR TITLE
fix: reduce E2E flakiness in CI dashboard tests

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -5,8 +5,8 @@ const isCI = !!process.env.CI;
 export default defineConfig({
   testDir: './tests/e2e/specs',
   testIgnore: ['**/demo-video.spec.ts'],
-  timeout: isCI ? 15_000 : 60_000,
-  retries: isCI ? 0 : 1,
+  timeout: isCI ? 30_000 : 60_000,
+  retries: isCI ? 1 : 1,
   use: {
     baseURL: 'http://localhost:3000',
     headless: true,

--- a/apps/web/tests/e2e/pages/setup.page.ts
+++ b/apps/web/tests/e2e/pages/setup.page.ts
@@ -112,6 +112,12 @@ export class SetupPage {
     await this.page
       .getByTestId('tab-content-dashboard')
       .waitFor({ state: 'visible', timeout: TIMEOUTS.API_RESPONSE });
+    // Wait for rider table to have at least one row before returning
+    await this.page
+      .getByTestId('dashboard-rider-table')
+      .locator('table tbody tr')
+      .first()
+      .waitFor({ state: 'visible', timeout: TIMEOUTS.API_RESPONSE });
   }
 
   async isAnalyzeDisabled(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Increase CI test timeout from 15s to 30s (full analyze round-trip needs more headroom)
- Add 1 retry in CI for transient slowness
- Wait for rider table rows to render in `analyzeValidRiders` before returning control to tests

## Test plan
- [ ] CI E2E passes without flaky failures
- [ ] Local E2E suite passes (71/71 verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)