### PR TITLE
feat: real-time SSE progress indicator for race analysis

### DIFF
--- a/apps/api/src/application/analyze/analyze-price-list.use-case.ts
+++ b/apps/api/src/application/analyze/analyze-price-list.use-case.ts
@@ -4,7 +4,9 @@ import {
   MlServiceUnavailableError,
   EmptyStartlistError,
   MlPredictionFailedError,
+  AnalysisCancelledError,
 } from '../../domain/analyze/errors';
+import type { ProgressNotifier } from './ports/progress-notifier.port';
 import {
   RiderMatcherPort,
   RIDER_MATCHER_PORT,
@@ -99,12 +101,16 @@ export class AnalyzePriceListUseCase {
     private readonly fetchStartlist: FetchStartlistUseCase,
   ) {}
 
-  async execute(input: AnalyzeInput): Promise<AnalyzeResponse> {
+  async execute(input: AnalyzeInput, notifier?: ProgressNotifier): Promise<AnalyzeResponse> {
     const entries = mapPriceListEntries(input.riders);
 
     if (entries.length === 0) {
       throw new EmptyPriceListError();
     }
+
+    // Step 1: matching_riders
+    const step1Start = Date.now();
+    notifier?.stepStarted('matching_riders');
 
     const allRiders = await this.riderRepo.findAll();
     const riderMap = new Map<string, Rider>();
@@ -126,6 +132,12 @@ export class AnalyzePriceListUseCase {
       })),
     );
 
+    notifier?.stepCompleted('matching_riders', Date.now() - step1Start);
+
+    // Step 2: loading_history
+    const step2Start = Date.now();
+    notifier?.stepStarted('loading_history');
+
     const matchedRiderIds = matchResults
       .filter((r) => r.match.matchedRiderId !== null)
       .map((r) => r.match.matchedRiderId as string);
@@ -144,6 +156,8 @@ export class AnalyzePriceListUseCase {
         resultsByRider.set(riderId, [result]);
       }
     }
+
+    notifier?.stepCompleted('loading_history', Date.now() - step2Start);
 
     interface MatchedEntry {
       entry: PriceListEntry;
@@ -188,7 +202,7 @@ export class AnalyzePriceListUseCase {
     });
 
     // --- ML prediction enrichment ---
-    const mlPredictions = await this.fetchMlPredictions(input);
+    const mlPredictions = await this.fetchMlPredictions(input, notifier);
 
     const analyzedRiders: AnalyzedRider[] = matchedEntries.map((s) => {
       if (s.unmatched || !s.matchedRider) {
@@ -239,6 +253,10 @@ export class AnalyzePriceListUseCase {
       };
     });
 
+    // Step 5: breakout_computation
+    const step5Start = Date.now();
+    notifier?.stepStarted('breakout_computation');
+
     // --- BPI computation ---
     const p75Pph = computeP75PtsPerHillio(analyzedRiders);
     for (const rider of analyzedRiders) {
@@ -260,6 +278,12 @@ export class AnalyzePriceListUseCase {
       });
     }
 
+    notifier?.stepCompleted('breakout_computation', Date.now() - step5Start);
+
+    // Step 6: building_results
+    const step6Start = Date.now();
+    notifier?.stepStarted('building_results');
+
     analyzedRiders.sort((a, b) => {
       const scoreA = a.totalProjectedPts;
       const scoreB = b.totalProjectedPts;
@@ -271,12 +295,16 @@ export class AnalyzePriceListUseCase {
 
     const totalMatched = analyzedRiders.filter((r) => !r.unmatched).length;
 
-    return {
+    const result: AnalyzeResponse = {
       riders: analyzedRiders,
       totalSubmitted: entries.length,
       totalMatched,
       unmatchedCount: entries.length - totalMatched,
     };
+
+    notifier?.stepCompleted('building_results', Date.now() - step6Start);
+
+    return result;
   }
 
   /**
@@ -284,7 +312,10 @@ export class AnalyzePriceListUseCase {
    * Ensures the race has a startlist in DB (scraped from PCS) so the ML
    * service can discover riders from its own data — no synthetic riderIds.
    */
-  private async fetchMlPredictions(input: AnalyzeInput): Promise<
+  private async fetchMlPredictions(
+    input: AnalyzeInput,
+    notifier?: ProgressNotifier,
+  ): Promise<
     Map<
       string,
       {
@@ -308,6 +339,16 @@ export class AnalyzePriceListUseCase {
       this.logger.debug(
         `ML cache hit for ${input.raceSlug}/${input.year} (model ${modelVersion}, ${cached.length} predictions)`,
       );
+
+      // Emit steps 3 & 4 instantly for cache hits
+      const step3Start = Date.now();
+      notifier?.stepStarted('fetching_startlist');
+      notifier?.stepCompleted('fetching_startlist', Date.now() - step3Start);
+
+      const step4Start = Date.now();
+      notifier?.stepStarted('ml_predictions');
+      notifier?.stepCompleted('ml_predictions', Date.now() - step4Start);
+
       return new Map(
         cached.map((s) => [
           s.riderId,
@@ -327,6 +368,10 @@ export class AnalyzePriceListUseCase {
       );
     }
 
+    // Step 3: fetching_startlist
+    const step3Start = Date.now();
+    notifier?.stepStarted('fetching_startlist');
+
     // Scrape the startlist from PCS and persist it in DB. The ML service reads
     // startlists from DB to discover which riders to predict for — we never
     // pass synthetic riderIds (that inflates rider count and breaks scaling).
@@ -341,6 +386,17 @@ export class AnalyzePriceListUseCase {
     this.logger.log(
       `Startlist ready for ${input.raceSlug}/${input.year}: ${startlistEntries.length} riders`,
     );
+
+    notifier?.stepCompleted('fetching_startlist', Date.now() - step3Start);
+
+    // Cancellation check before the most expensive operation
+    if (notifier?.isCancelled) {
+      throw new AnalysisCancelledError();
+    }
+
+    // Step 4: ml_predictions
+    const step4Start = Date.now();
+    notifier?.stepStarted('ml_predictions');
 
     // Cache miss — call ML service (pass race profile for v4 features)
     const profileForMl = input.profileSummary
@@ -364,6 +420,8 @@ export class AnalyzePriceListUseCase {
     if (!predictions) {
       throw new MlPredictionFailedError(input.raceSlug!, input.year!);
     }
+
+    notifier?.stepCompleted('ml_predictions', Date.now() - step4Start);
 
     this.logger.log(
       `ML predictions received for ${input.raceSlug}/${input.year}: ${predictions.length} riders`,

--- a/apps/api/src/application/analyze/ports/progress-notifier.port.ts
+++ b/apps/api/src/application/analyze/ports/progress-notifier.port.ts
@@ -1,0 +1,8 @@
+import type { AnalysisStepId } from '@cycling-analyzer/shared-types';
+
+export interface ProgressNotifier {
+  stepStarted(step: AnalysisStepId): void;
+  stepCompleted(step: AnalysisStepId, elapsedMs: number): void;
+  stepFailed(step: AnalysisStepId, message: string): void;
+  readonly isCancelled: boolean;
+}

--- a/apps/api/src/domain/analyze/errors.ts
+++ b/apps/api/src/domain/analyze/errors.ts
@@ -58,3 +58,10 @@ export class EmptyPriceListPageError extends Error {
     this.name = 'EmptyPriceListPageError';
   }
 }
+
+export class AnalysisCancelledError extends Error {
+  constructor() {
+    super('Analysis cancelled by client');
+    this.name = 'AnalysisCancelledError';
+  }
+}

--- a/apps/api/src/presentation/__tests__/analyze.controller.spec.ts
+++ b/apps/api/src/presentation/__tests__/analyze.controller.spec.ts
@@ -59,24 +59,40 @@ describe('AnalyzeController', () => {
     expect(controller).toBeDefined();
   });
 
-  it('should call use case with correct input and return response', async () => {
+  it('should call use case with correct input and stream SSE response', async () => {
     const dto = {
       riders: [{ name: 'POGACAR Tadej', team: 'UAE', price: 300 }],
       raceType: 'grand_tour' as const,
       budget: 2000,
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test DTO doesn't need full class instance
-    const result = await controller.analyze(dto as any);
+    const mockReq = { on: jest.fn() } as unknown as import('express').Request;
+    const written: string[] = [];
+    const mockRes = {
+      setHeader: jest.fn(),
+      flushHeaders: jest.fn(),
+      write: jest.fn((chunk: string) => written.push(chunk)),
+      end: jest.fn(),
+    } as unknown as import('express').Response;
 
-    expect(mockUseCase.execute).toHaveBeenCalledWith({
-      riders: dto.riders,
-      raceType: dto.raceType,
-      budget: dto.budget,
-      profileSummary: undefined,
-      raceSlug: undefined,
-      year: undefined,
-    });
-    expect(result).toEqual(sampleResponse);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test DTO doesn't need full class instance
+    await controller.analyze(dto as any, mockReq, mockRes);
+
+    expect(mockUseCase.execute).toHaveBeenCalledWith(
+      {
+        riders: dto.riders,
+        raceType: dto.raceType,
+        budget: dto.budget,
+        profileSummary: undefined,
+        raceSlug: undefined,
+        year: undefined,
+      },
+      expect.any(Object),
+    );
+    expect(mockRes.setHeader).toHaveBeenCalledWith('Content-Type', 'text/event-stream');
+    expect(mockRes.end).toHaveBeenCalled();
+    // The result event should have been written to the stream
+    const resultEvent = written.find((w) => w.startsWith('event: result'));
+    expect(resultEvent).toBeDefined();
   });
 });

--- a/apps/api/src/presentation/analyze.controller.ts
+++ b/apps/api/src/presentation/analyze.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Query, Body, BadRequestException } from '@nestjs/common';
+import { Controller, Post, Get, Query, Body, BadRequestException, Req, Res } from '@nestjs/common';
 import {
   IsString,
   IsNotEmpty,
@@ -12,15 +12,22 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { Request, Response } from 'express';
 import { RaceType } from '../domain/shared/race-type.enum';
-import {
-  AnalyzePriceListUseCase,
-  AnalyzeResponse,
-} from '../application/analyze/analyze-price-list.use-case';
+import { AnalyzePriceListUseCase } from '../application/analyze/analyze-price-list.use-case';
 import {
   ImportPriceListUseCase,
   ParsedPriceEntry,
 } from '../application/analyze/import-price-list.use-case';
+import {
+  EmptyPriceListError,
+  EmptyStartlistError,
+  MlServiceUnavailableError,
+  MlPredictionFailedError,
+  AnalysisCancelledError,
+} from '../domain/analyze/errors';
+import type { AnalysisStepId } from '@cycling-analyzer/shared-types';
+import { SseProgressNotifier } from './sse-progress-notifier';
 
 class PriceListEntryDto {
   @IsString()
@@ -106,15 +113,56 @@ export class AnalyzeController {
   ) {}
 
   @Post('analyze')
-  async analyze(@Body() dto: AnalyzeRequestDto): Promise<AnalyzeResponse> {
-    return this.analyzeUseCase.execute({
-      riders: dto.riders,
-      raceType: dto.raceType,
-      budget: dto.budget,
-      profileSummary: dto.profileSummary,
-      raceSlug: dto.raceSlug,
-      year: dto.year,
-    });
+  async analyze(
+    @Body() dto: AnalyzeRequestDto,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    const notifier = new SseProgressNotifier(res, req);
+
+    try {
+      const result = await this.analyzeUseCase.execute(
+        {
+          riders: dto.riders,
+          raceType: dto.raceType,
+          budget: dto.budget,
+          profileSummary: dto.profileSummary,
+          raceSlug: dto.raceSlug,
+          year: dto.year,
+        },
+        notifier,
+      );
+
+      // The use case AnalyzeResponse uses a narrower categoryScores type than shared-types
+      // AnalysisResultEvent (which includes all ResultCategory keys). The extra keys are only
+      // relevant for detailed scoring; the SSE payload carries the same shape the client expects.
+      notifier.sendResult(
+        result as unknown as import('@cycling-analyzer/shared-types').AnalysisResultEvent,
+      );
+    } catch (error) {
+      if (error instanceof AnalysisCancelledError) {
+        // Client disconnected — silently close
+      } else {
+        const step = this.mapErrorToStep(error);
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        notifier.stepFailed(step, message);
+      }
+    } finally {
+      res.end();
+    }
+  }
+
+  private mapErrorToStep(error: unknown): AnalysisStepId {
+    if (error instanceof EmptyPriceListError) return 'matching_riders';
+    if (error instanceof EmptyStartlistError) return 'fetching_startlist';
+    if (error instanceof MlServiceUnavailableError) return 'ml_predictions';
+    if (error instanceof MlPredictionFailedError) return 'ml_predictions';
+    return 'building_results';
   }
 
   @Get('import-price-list')

--- a/apps/api/src/presentation/sse-progress-notifier.ts
+++ b/apps/api/src/presentation/sse-progress-notifier.ts
@@ -1,0 +1,74 @@
+import type { Request, Response } from 'express';
+import type { ProgressNotifier } from '../application/analyze/ports/progress-notifier.port';
+import type {
+  AnalysisStepId,
+  AnalysisProgressEvent,
+  AnalysisErrorEvent,
+  AnalysisResultEvent,
+} from '@cycling-analyzer/shared-types';
+
+const TOTAL_STEPS = 6;
+
+const STEP_INDEX: Record<AnalysisStepId, number> = {
+  matching_riders: 1,
+  loading_history: 2,
+  fetching_startlist: 3,
+  ml_predictions: 4,
+  breakout_computation: 5,
+  building_results: 6,
+};
+
+export class SseProgressNotifier implements ProgressNotifier {
+  private cancelled = false;
+
+  constructor(
+    private readonly res: Response,
+    req: Request,
+  ) {
+    req.on('close', () => {
+      this.cancelled = true;
+    });
+  }
+
+  get isCancelled(): boolean {
+    return this.cancelled;
+  }
+
+  stepStarted(step: AnalysisStepId): void {
+    if (this.cancelled) return;
+    const event: AnalysisProgressEvent = {
+      step,
+      status: 'in_progress',
+      stepIndex: STEP_INDEX[step],
+      totalSteps: TOTAL_STEPS,
+    };
+    this.sendEvent('progress', event);
+  }
+
+  stepCompleted(step: AnalysisStepId, elapsedMs: number): void {
+    if (this.cancelled) return;
+    const event: AnalysisProgressEvent = {
+      step,
+      status: 'completed',
+      stepIndex: STEP_INDEX[step],
+      totalSteps: TOTAL_STEPS,
+      elapsedMs,
+    };
+    this.sendEvent('progress', event);
+  }
+
+  stepFailed(step: AnalysisStepId, message: string): void {
+    if (this.cancelled) return;
+    const event: AnalysisErrorEvent = { step, message };
+    this.sendEvent('error', event);
+  }
+
+  sendResult(result: AnalysisResultEvent): void {
+    if (this.cancelled) return;
+    this.sendEvent('result', result);
+  }
+
+  private sendEvent(type: string, data: unknown): void {
+    this.res.write(`event: ${type}\ndata: ${JSON.stringify(data)}\n\n`);
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@cycling-analyzer/shared-types": "workspace:*",
+    "@microsoft/fetch-event-source": "^2.0.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-popover": "^1.1.15",

--- a/apps/web/src/features/rider-list/__tests__/use-analyze.spec.ts
+++ b/apps/web/src/features/rider-list/__tests__/use-analyze.spec.ts
@@ -1,17 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useAnalyze } from '../hooks/use-analyze';
 import { RaceType } from '@cycling-analyzer/shared-types';
 import type { AnalyzeResponse } from '@cycling-analyzer/shared-types';
 
-const mockFetch = vi.fn();
+vi.mock('@/shared/lib/api-client', () => ({
+  analyzeRidersStream: vi.fn(),
+}));
+
+import { analyzeRidersStream } from '@/shared/lib/api-client';
+
+const mockStream = vi.mocked(analyzeRidersStream);
 
 beforeEach(() => {
-  vi.stubGlobal('fetch', mockFetch);
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
+  vi.clearAllMocks();
 });
 
 const sampleResponse: AnalyzeResponse = {
@@ -21,100 +23,109 @@ const sampleResponse: AnalyzeResponse = {
   unmatchedCount: 1,
 };
 
+const sampleRequest = {
+  riders: [{ name: 'Test', team: 'Team', price: 100 }],
+  raceType: RaceType.GRAND_TOUR,
+  budget: 2000,
+};
+
 describe('useAnalyze', () => {
   it('starts with idle state', () => {
     const { result } = renderHook(() => useAnalyze());
     expect(result.current.state.status).toBe('idle');
   });
 
-  it('sets loading during request', async () => {
-    let resolvePromise: (v: unknown) => void;
-    mockFetch.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolvePromise = resolve;
-      }),
+  it('sets loading during request with initial steps', async () => {
+    let resolveStream: () => void;
+    mockStream.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStream = resolve;
+        }),
     );
 
     const { result } = renderHook(() => useAnalyze());
 
     act(() => {
-      void result.current.analyze({
-        riders: [{ name: 'Test', team: 'Team', price: 100 }],
-        raceType: RaceType.GRAND_TOUR,
-        budget: 2000,
-      });
+      void result.current.analyze(sampleRequest);
     });
 
     expect(result.current.state.status).toBe('loading');
+    if (result.current.state.status === 'loading') {
+      expect(result.current.state.steps).toHaveLength(6);
+      expect(result.current.state.steps[0].status).toBe('pending');
+    }
 
     await act(async () => {
-      resolvePromise!({
-        ok: true,
-        json: () => Promise.resolve(sampleResponse),
-      });
+      resolveStream!();
     });
-
-    expect(result.current.state.status).toBe('success');
   });
 
-  it('sets data on success', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(sampleResponse),
+  it('transitions to success when result event received', async () => {
+    mockStream.mockImplementationOnce(async (_req, callbacks) => {
+      callbacks.onProgress({
+        step: 'matching_riders',
+        status: 'in_progress',
+        stepIndex: 1,
+        totalSteps: 6,
+      });
+      callbacks.onProgress({
+        step: 'matching_riders',
+        status: 'completed',
+        stepIndex: 1,
+        totalSteps: 6,
+        elapsedMs: 100,
+      });
+      callbacks.onResult(sampleResponse);
     });
 
     const { result } = renderHook(() => useAnalyze());
 
     await act(async () => {
-      await result.current.analyze({
-        riders: [{ name: 'Test', team: 'Team', price: 100 }],
-        raceType: RaceType.GRAND_TOUR,
-        budget: 2000,
-      });
+      await result.current.analyze(sampleRequest);
     });
 
     expect(result.current.state.status).toBe('success');
     if (result.current.state.status === 'success') {
       expect(result.current.state.data).toEqual(sampleResponse);
+      expect(result.current.state.steps).toHaveLength(6);
     }
   });
 
-  it('sets error on failure', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      statusText: 'Internal Server Error',
+  it('sets error on failure event', async () => {
+    mockStream.mockImplementationOnce(async (_req, callbacks) => {
+      callbacks.onProgress({
+        step: 'matching_riders',
+        status: 'completed',
+        stepIndex: 1,
+        totalSteps: 6,
+        elapsedMs: 50,
+      });
+      callbacks.onError({ step: 'ml_predictions', message: 'ML service unavailable' });
     });
 
     const { result } = renderHook(() => useAnalyze());
 
     await act(async () => {
-      await result.current.analyze({
-        riders: [{ name: 'Test', team: 'Team', price: 100 }],
-        raceType: RaceType.GRAND_TOUR,
-        budget: 2000,
-      });
+      await result.current.analyze(sampleRequest);
     });
 
     expect(result.current.state.status).toBe('error');
     if (result.current.state.status === 'error') {
-      expect(result.current.state.error).toBeTruthy();
+      expect(result.current.state.error).toBe('ML service unavailable');
+      expect(result.current.state.failedStep).toBe('ml_predictions');
     }
   });
 
   it('resets state', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(sampleResponse),
+    mockStream.mockImplementationOnce(async (_req, callbacks) => {
+      callbacks.onResult(sampleResponse);
     });
 
     const { result } = renderHook(() => useAnalyze());
 
     await act(async () => {
-      await result.current.analyze({
-        riders: [{ name: 'Test', team: 'Team', price: 100 }],
-        raceType: RaceType.GRAND_TOUR,
-        budget: 2000,
-      });
+      await result.current.analyze(sampleRequest);
     });
 
     expect(result.current.state.status).toBe('success');
@@ -127,30 +138,20 @@ describe('useAnalyze', () => {
   });
 
   it('retries last request', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve(sampleResponse),
+    mockStream.mockImplementation(async (_req, callbacks) => {
+      callbacks.onResult(sampleResponse);
     });
 
     const { result } = renderHook(() => useAnalyze());
 
     await act(async () => {
-      await result.current.analyze({
-        riders: [{ name: 'Test', team: 'Team', price: 100 }],
-        raceType: RaceType.GRAND_TOUR,
-        budget: 2000,
-      });
-    });
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: () => Promise.resolve({ ...sampleResponse, totalSubmitted: 2 }),
+      await result.current.analyze(sampleRequest);
     });
 
     await act(async () => {
       result.current.retry();
     });
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockStream).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/features/rider-list/__tests__/use-analyze.spec.ts
+++ b/apps/web/src/features/rider-list/__tests__/use-analyze.spec.ts
@@ -62,6 +62,8 @@ describe('useAnalyze', () => {
   });
 
   it('transitions to success when result event received', async () => {
+    vi.useFakeTimers();
+
     mockStream.mockImplementationOnce(async (_req, callbacks) => {
       callbacks.onProgress({
         step: 'matching_riders',
@@ -85,11 +87,20 @@ describe('useAnalyze', () => {
       await result.current.analyze(sampleRequest);
     });
 
+    // After result event, steps are all completed but state is still loading (delay)
+    expect(result.current.state.status).toBe('loading');
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
     expect(result.current.state.status).toBe('success');
     if (result.current.state.status === 'success') {
       expect(result.current.state.data).toEqual(sampleResponse);
       expect(result.current.state.steps).toHaveLength(6);
     }
+
+    vi.useRealTimers();
   });
 
   it('sets error on failure event', async () => {
@@ -118,6 +129,8 @@ describe('useAnalyze', () => {
   });
 
   it('resets state', async () => {
+    vi.useFakeTimers();
+
     mockStream.mockImplementationOnce(async (_req, callbacks) => {
       callbacks.onResult(sampleResponse);
     });
@@ -128,6 +141,10 @@ describe('useAnalyze', () => {
       await result.current.analyze(sampleRequest);
     });
 
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
     expect(result.current.state.status).toBe('success');
 
     act(() => {
@@ -135,9 +152,13 @@ describe('useAnalyze', () => {
     });
 
     expect(result.current.state.status).toBe('idle');
+
+    vi.useRealTimers();
   });
 
   it('retries last request', async () => {
+    vi.useFakeTimers();
+
     mockStream.mockImplementation(async (_req, callbacks) => {
       callbacks.onResult(sampleResponse);
     });
@@ -149,9 +170,19 @@ describe('useAnalyze', () => {
     });
 
     await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    await act(async () => {
       result.current.retry();
     });
 
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
     expect(mockStream).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/features/rider-list/components/analysis-progress.tsx
+++ b/apps/web/src/features/rider-list/components/analysis-progress.tsx
@@ -1,0 +1,96 @@
+import { Circle, CheckCircle2, XCircle, Loader2, RefreshCw } from 'lucide-react';
+import type { StepState, StepStatus } from '../hooks/use-analyze';
+
+interface AnalysisProgressProps {
+  steps: StepState[];
+  error?: string;
+  failedStep?: string;
+  onRetry?: () => void;
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function StepIcon({ status }: { status: StepStatus }) {
+  switch (status) {
+    case 'pending':
+      return <Circle className="h-5 w-5 text-outline" />;
+    case 'in_progress':
+      return <Loader2 className="h-5 w-5 animate-spin text-primary" />;
+    case 'completed':
+      return <CheckCircle2 className="h-5 w-5 text-tertiary" />;
+    case 'failed':
+      return <XCircle className="h-5 w-5 text-error" />;
+  }
+}
+
+function stepTextClass(status: StepStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'text-outline';
+    case 'in_progress':
+      return 'font-medium text-on-surface';
+    case 'completed':
+      return 'text-on-surface-variant';
+    case 'failed':
+      return 'text-error font-medium';
+  }
+}
+
+function ProgressStep({ step }: { step: StepState }) {
+  return (
+    <div
+      className="flex items-center gap-3 py-1.5"
+      role="listitem"
+      aria-label={`${step.displayName}: ${step.status.replace('_', ' ')}`}
+    >
+      <StepIcon status={step.status} />
+      <span className={`text-sm ${stepTextClass(step.status)}`}>{step.displayName}</span>
+      {step.status === 'completed' && step.elapsedMs != null && (
+        <span className="ml-auto font-mono text-xs text-outline">
+          {formatElapsed(step.elapsedMs)}
+        </span>
+      )}
+      {step.status === 'failed' && step.errorMessage && (
+        <span className="ml-auto text-xs text-error">{step.errorMessage}</span>
+      )}
+    </div>
+  );
+}
+
+export function AnalysisProgress({ steps, error, failedStep, onRetry }: AnalysisProgressProps) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center p-8">
+      <div className="w-full max-w-sm space-y-1">
+        <div className="flex items-center gap-2 mb-4">
+          <span className="text-outline font-mono text-xs uppercase tracking-tight">
+            {error ? 'Analysis Failed' : 'Analyzing Riders'}
+          </span>
+        </div>
+        <div role="list" aria-label="Analysis steps">
+          {steps.map((step) => (
+            <ProgressStep key={step.id} step={step} />
+          ))}
+        </div>
+        {error && (
+          <div className="mt-6 rounded-sm border border-error/20 bg-error-container/[0.06] p-4">
+            <p className="text-sm font-mono text-error leading-relaxed">
+              {failedStep ? error : 'Connection lost. Please try again.'}
+            </p>
+            {onRetry && (
+              <button
+                onClick={onRetry}
+                className="mt-3 inline-flex items-center gap-2 px-4 py-2 bg-error/10 hover:bg-error/20 border border-error/30 text-error font-mono font-bold text-xs uppercase tracking-wider rounded-sm transition-all hover:scale-[1.02] active:scale-[0.98]"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Retry Analysis
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/rider-list/hooks/use-analyze.ts
+++ b/apps/web/src/features/rider-list/hooks/use-analyze.ts
@@ -1,20 +1,97 @@
-import { useState, useCallback } from 'react';
-import type { AnalyzeRequest, AnalyzeResponse } from '@cycling-analyzer/shared-types';
-import type { AsyncState } from '@/shared/lib/async-state';
-import { analyzeRiders } from '@/shared/lib/api-client';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import type {
+  AnalyzeRequest,
+  AnalyzeResponse,
+  AnalysisStepId,
+} from '@cycling-analyzer/shared-types';
+import { ANALYSIS_STEPS } from '@cycling-analyzer/shared-types';
+import { analyzeRidersStream } from '@/shared/lib/api-client';
+
+export type StepStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+
+export interface StepState {
+  id: AnalysisStepId;
+  displayName: string;
+  status: StepStatus;
+  elapsedMs?: number;
+  errorMessage?: string;
+}
+
+export type AnalyzeState =
+  | { status: 'idle' }
+  | { status: 'loading'; steps: StepState[] }
+  | { status: 'success'; data: AnalyzeResponse; steps: StepState[] }
+  | { status: 'error'; error: string; steps: StepState[]; failedStep?: AnalysisStepId };
+
+function createInitialSteps(): StepState[] {
+  return ANALYSIS_STEPS.map((s) => ({
+    id: s.id,
+    displayName: s.displayName,
+    status: 'pending' as StepStatus,
+  }));
+}
 
 export function useAnalyze() {
-  const [state, setState] = useState<AsyncState<AnalyzeResponse>>({ status: 'idle' });
+  const [state, setState] = useState<AnalyzeState>({ status: 'idle' });
   const [lastRequest, setLastRequest] = useState<AnalyzeRequest | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const analyze = useCallback(async (request: AnalyzeRequest) => {
-    setState({ status: 'loading' });
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     setLastRequest(request);
-    const response = await analyzeRiders(request);
-    if (response.status === 'success') {
-      setState({ status: 'success', data: response.data });
-    } else {
-      setState({ status: 'error', error: response.error });
+    setState({ status: 'loading', steps: createInitialSteps() });
+
+    try {
+      await analyzeRidersStream(request, {
+        signal: controller.signal,
+        onProgress(event) {
+          setState((prev) => {
+            if (prev.status !== 'loading') return prev;
+            const steps = prev.steps.map((s) =>
+              s.id === event.step
+                ? { ...s, status: event.status as StepStatus, elapsedMs: event.elapsedMs }
+                : s,
+            );
+            return { ...prev, steps };
+          });
+        },
+        onResult(result) {
+          setState((prev) => {
+            const steps =
+              prev.status === 'loading'
+                ? prev.steps.map((s) =>
+                    s.status !== 'completed' ? { ...s, status: 'completed' as StepStatus } : s,
+                  )
+                : createInitialSteps();
+            return { status: 'success', data: result, steps };
+          });
+        },
+        onError(error) {
+          setState((prev) => {
+            const steps = prev.status === 'loading' ? prev.steps : createInitialSteps();
+            const failedStep = 'step' in error ? error.step : undefined;
+            if (failedStep) {
+              const updatedSteps = steps.map((s) =>
+                s.id === failedStep
+                  ? { ...s, status: 'failed' as StepStatus, errorMessage: error.message }
+                  : s,
+              );
+              return { status: 'error', error: error.message, steps: updatedSteps, failedStep };
+            }
+            return { status: 'error', error: error.message, steps };
+          });
+        },
+      });
+    } catch {
+      if (!controller.signal.aborted) {
+        setState((prev) => {
+          const steps = prev.status === 'loading' ? prev.steps : createInitialSteps();
+          return { status: 'error', error: 'Connection lost', steps };
+        });
+      }
     }
   }, []);
 
@@ -25,8 +102,15 @@ export function useAnalyze() {
   }, [lastRequest, analyze]);
 
   const reset = useCallback(() => {
+    abortRef.current?.abort();
     setState({ status: 'idle' });
     setLastRequest(null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
   }, []);
 
   return { state, analyze, retry, reset };

--- a/apps/web/src/features/rider-list/hooks/use-analyze.ts
+++ b/apps/web/src/features/rider-list/hooks/use-analyze.ts
@@ -59,15 +59,21 @@ export function useAnalyze() {
           });
         },
         onResult(result) {
+          // Mark all steps as completed first so the user sees them finish
           setState((prev) => {
-            const steps =
-              prev.status === 'loading'
-                ? prev.steps.map((s) =>
-                    s.status !== 'completed' ? { ...s, status: 'completed' as StepStatus } : s,
-                  )
-                : createInitialSteps();
-            return { status: 'success', data: result, steps };
+            if (prev.status !== 'loading') return prev;
+            const steps = prev.steps.map((s) =>
+              s.status !== 'completed' ? { ...s, status: 'completed' as StepStatus } : s,
+            );
+            return { ...prev, steps };
           });
+          // Brief delay before showing results so the last steps are visible
+          setTimeout(() => {
+            setState((prev) => {
+              const steps = 'steps' in prev ? prev.steps : createInitialSteps();
+              return { status: 'success', data: result, steps };
+            });
+          }, 600);
         },
         onError(error) {
           setState((prev) => {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -296,6 +296,8 @@ function HomePageContent() {
               onAnalyze={handleAnalyze}
               isLoading={isAnalyzing}
               error={analyzeState.status === 'error' ? analyzeState.error : undefined}
+              analyzeSteps={'steps' in analyzeState ? analyzeState.steps : undefined}
+              failedStep={analyzeState.status === 'error' ? analyzeState.failedStep : undefined}
               onRetry={retryAnalyze}
               budget={budget}
               riderText={riderText}

--- a/apps/web/src/routes/tabs/-setup-tab.tsx
+++ b/apps/web/src/routes/tabs/-setup-tab.tsx
@@ -6,9 +6,10 @@ import type {
 } from '@cycling-analyzer/shared-types';
 import { type RaceType } from '@cycling-analyzer/shared-types';
 import { RiderInput } from '@/features/rider-list/components/rider-input';
-import { LoadingSpinner } from '@/shared/ui/loading-spinner';
-import { TableSkeleton } from '@/shared/ui/table-skeleton';
+import { AnalysisProgress } from '@/features/rider-list/components/analysis-progress';
 import { TrendingUp, AlertTriangle, RefreshCw, CheckCircle2, RotateCcw } from 'lucide-react';
+import type { StepState } from '@/features/rider-list/hooks/use-analyze';
+import type { AnalysisStepId } from '@cycling-analyzer/shared-types';
 import type { useRaceProfile } from '@/features/rider-list/hooks/use-race-profile';
 import type { GmvImportState } from '@/features/rider-list/hooks/use-gmv-auto-import';
 
@@ -23,6 +24,8 @@ export interface SetupTabProps {
   ) => void;
   isLoading: boolean;
   error?: string;
+  analyzeSteps?: StepState[];
+  failedStep?: AnalysisStepId;
   onRetry?: () => void;
   onReset?: () => void;
   budget: number;
@@ -50,6 +53,8 @@ export function SetupTab({
   onAnalyze,
   isLoading,
   error,
+  analyzeSteps,
+  failedStep,
   onRetry,
   onReset,
   budget,
@@ -120,8 +125,16 @@ export function SetupTab({
           </div>
         </div>
 
-        {error ? (
-          /* Error state */
+        {error && analyzeSteps ? (
+          /* Error state with step progress */
+          <AnalysisProgress
+            steps={analyzeSteps}
+            error={error}
+            failedStep={failedStep}
+            onRetry={onRetry}
+          />
+        ) : error ? (
+          /* Error state without steps (fallback) */
           <div className="flex-1 rounded-sm bg-error-container/[0.06] border border-error/20 flex flex-col items-center justify-center p-8 relative overflow-hidden animate-fade-in">
             <div
               className="absolute inset-0 opacity-[0.03] pointer-events-none"
@@ -170,14 +183,10 @@ export function SetupTab({
               </div>
             </div>
           </div>
+        ) : isLoading && analyzeSteps ? (
+          <AnalysisProgress steps={analyzeSteps} />
         ) : isLoading ? (
-          <div className="flex-1 flex flex-col gap-4">
-            <div className="flex items-center gap-3 px-1">
-              <LoadingSpinner />
-              <span className="text-sm text-on-surface-variant">Analyzing riders...</span>
-            </div>
-            <TableSkeleton rows={10} />
-          </div>
+          <AnalysisProgress steps={[]} />
         ) : hasResult ? (
           /* Analysis complete — show summary */
           <div className="hidden lg:flex flex-1 rounded-sm bg-surface-container-low/30 border border-secondary/20 flex-col items-center justify-center p-6 relative overflow-hidden">

--- a/apps/web/src/shared/lib/api-client.ts
+++ b/apps/web/src/shared/lib/api-client.ts
@@ -1,6 +1,11 @@
+import { fetchEventSource } from '@microsoft/fetch-event-source';
 import type {
   AnalyzeRequest,
   AnalyzeResponse,
+  AnalysisProgressEvent,
+  AnalysisResultEvent,
+  AnalysisErrorEvent,
+  AnalysisSseEventType,
   OptimizeRequest,
   OptimizeResponse,
   RaceProfileResponse,
@@ -66,6 +71,45 @@ async function apiGet<TRes>(path: string, signal?: AbortSignal): Promise<ApiResu
 
 export function analyzeRiders(request: AnalyzeRequest): Promise<ApiResult<AnalyzeResponse>> {
   return apiPost<AnalyzeRequest, AnalyzeResponse>('/api/analyze', request);
+}
+
+export interface AnalyzeStreamCallbacks {
+  onProgress: (event: AnalysisProgressEvent) => void;
+  onResult: (result: AnalysisResultEvent) => void;
+  onError: (error: AnalysisErrorEvent | { message: string }) => void;
+  signal?: AbortSignal;
+}
+
+export async function analyzeRidersStream(
+  request: AnalyzeRequest,
+  callbacks: AnalyzeStreamCallbacks,
+): Promise<void> {
+  await fetchEventSource(`${API_BASE_URL}/api/analyze`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(request),
+    signal: callbacks.signal,
+    openWhenHidden: true,
+    onmessage(ev) {
+      const eventType = ev.event as AnalysisSseEventType;
+      const data = JSON.parse(ev.data);
+      switch (eventType) {
+        case 'progress':
+          callbacks.onProgress(data as AnalysisProgressEvent);
+          break;
+        case 'result':
+          callbacks.onResult(data as AnalysisResultEvent);
+          break;
+        case 'error':
+          callbacks.onError(data as AnalysisErrorEvent);
+          break;
+      }
+    },
+    onerror(err) {
+      callbacks.onError({ message: err?.message ?? 'Connection lost' });
+      throw err; // prevent auto-retry
+    },
+  });
 }
 
 export function optimizeTeam(request: OptimizeRequest): Promise<ApiResult<OptimizeResponse>> {

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -160,3 +160,47 @@ export interface GmvMatchResponse {
   confidence: number | null;
   riders: PriceListEntryDto[] | null;
 }
+
+// --- SSE Analysis Progress Types ---
+
+export type AnalysisStepId =
+  | 'matching_riders'
+  | 'loading_history'
+  | 'fetching_startlist'
+  | 'ml_predictions'
+  | 'breakout_computation'
+  | 'building_results';
+
+export interface AnalysisStep {
+  id: AnalysisStepId;
+  displayName: string;
+  index: number;
+}
+
+export const ANALYSIS_STEPS: readonly AnalysisStep[] = [
+  { id: 'matching_riders', displayName: 'Match Riders', index: 1 },
+  { id: 'loading_history', displayName: 'Load Race History', index: 2 },
+  { id: 'fetching_startlist', displayName: 'Fetch Startlist', index: 3 },
+  { id: 'ml_predictions', displayName: 'Generate ML Predictions', index: 4 },
+  { id: 'breakout_computation', displayName: 'Compute Breakout Analysis', index: 5 },
+  { id: 'building_results', displayName: 'Build Results', index: 6 },
+] as const;
+
+export const TOTAL_ANALYSIS_STEPS = ANALYSIS_STEPS.length;
+
+export interface AnalysisProgressEvent {
+  step: AnalysisStepId;
+  status: 'in_progress' | 'completed';
+  stepIndex: number;
+  totalSteps: number;
+  elapsedMs?: number;
+}
+
+export type AnalysisResultEvent = AnalyzeResponse;
+
+export interface AnalysisErrorEvent {
+  step: AnalysisStepId;
+  message: string;
+}
+
+export type AnalysisSseEventType = 'progress' | 'result' | 'error';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@cycling-analyzer/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types
+      '@microsoft/fetch-event-source':
+        specifier: ^2.0.1
+        version: 2.0.1
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.2.4)(react@19.2.4)
@@ -2325,6 +2328,10 @@ packages:
   /@lukeed/csprng@1.1.0:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  /@microsoft/fetch-event-source@2.0.1:
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
+    dev: false
 
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}


### PR DESCRIPTION
## Summary

- Replace the synchronous `POST /api/analyze` endpoint with an SSE-streaming endpoint that emits step-by-step progress events during the 6 analysis phases
- Add `ProgressNotifier` port in the application layer (DDD/Hexagonal compliant) with `SseProgressNotifier` adapter in presentation
- Frontend uses `@microsoft/fetch-event-source` to consume the SSE stream, with a new `AnalysisProgress` component showing live step status, elapsed times, and error details
- Client disconnect detection aborts expensive ML predictions early

## Changes

**Backend** (apps/api/):
- `ProgressNotifier` port interface (`application/analyze/ports/`)
- `SseProgressNotifier` adapter (`presentation/`)
- `AnalyzePriceListUseCase` instrumented with 6 progress steps + cancellation check
- Controller streams SSE with manual headers, maps domain errors to step identifiers

**Frontend** (apps/web/):
- `@microsoft/fetch-event-source` dependency for POST+SSE
- `analyzeRidersStream()` in api-client with typed event callbacks
- `useAnalyze` hook refactored for per-step progress state tracking
- `AnalysisProgress` component with step icons, elapsed time, error display + retry
- SetupTab integration replacing the generic loading spinner

**Shared** (packages/shared-types/):
- `AnalysisStepId`, `AnalysisStep`, `ANALYSIS_STEPS` constants
- `AnalysisProgressEvent`, `AnalysisResultEvent`, `AnalysisErrorEvent` types

## Test plan

- [x] API unit tests: 40 suites, 466 tests passing
- [x] Web unit tests: 17 suites, 112 tests passing (including updated use-analyze tests)
- [x] TypeScript: both API and web typecheck clean
- [x] ESLint: all 3 packages lint clean
- [ ] E2E: manual verification with `make dev` — submit price list, observe step progress, verify results
- [ ] E2E: stop ML service, verify error shown on ML prediction step with retry button

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)