### PR TITLE
fix: improve logging for key error paths and operational tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ __pycache__/
 *.pyc
 ml/.coverage
 redesign/
+tools/
 ml/cache/
 ml/logbook/
 ml/results/

--- a/apps/api/src/application/analyze/analyze-price-list.use-case.ts
+++ b/apps/api/src/application/analyze/analyze-price-list.use-case.ts
@@ -418,6 +418,11 @@ export class AnalyzePriceListUseCase {
       input.raceType,
     );
     if (!predictions) {
+      this.logger.error(
+        `ML prediction failed for ${input.raceSlug}/${input.year} ` +
+          `(raceType=${input.raceType}, startlist=${startlistEntries.length}) — ` +
+          `ML service returned no predictions`,
+      );
       throw new MlPredictionFailedError(input.raceSlug!, input.year!);
     }
 

--- a/apps/api/src/infrastructure/ml/ml-scoring.adapter.ts
+++ b/apps/api/src/infrastructure/ml/ml-scoring.adapter.ts
@@ -70,8 +70,12 @@ export class MlScoringAdapter implements MlScoringPort {
         predictedScore: p.predicted_score,
         breakdown: p.breakdown ?? DEFAULT_BREAKDOWN,
       }));
-    } catch {
-      this.logger.warn(`ML service unavailable for predictRace(${raceSlug}, ${year})`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.error(
+        `ML service unavailable for predictRace(${raceSlug}, ${year}): ${message}`,
+        err instanceof Error ? err.stack : undefined,
+      );
       return null;
     }
   }

--- a/docs/runbooks/retraining-runbook.md
+++ b/docs/runbooks/retraining-runbook.md
@@ -89,6 +89,28 @@ Note: these have dependencies — e.g., train_sources requires cache + stage
 targets + stage features to exist. Use `make retrain` unless you know what
 you're doing.
 
+## Detached / Background Runs
+
+Detached invocations like `docker exec -d ... python -m src.training.retrain` lose
+stdout and stderr. The script always tees its full output to `<cache>/retrain.log`
+and writes `<cache>/retrain_status.json` on completion (success or failure) so you
+can verify the run.
+
+```bash
+# Inspect last run
+cat ml/cache/retrain_status.json   # exit_code, duration_seconds, model_version, error
+tail -n 100 ml/cache/retrain.log
+```
+
+`retrain_status.json` fields:
+
+- `status`: `success` | `failed`
+- `exit_code`: `0` | `1`
+- `started_at`, `completed_at`: ISO-8601 UTC timestamps
+- `duration_seconds`: total wall-clock duration
+- `model_version`: only on success
+- `error`, `traceback`: only on failure
+
 ## Troubleshooting
 
 | Issue                        | Cause                                      | Fix                                                                               |

--- a/ml/src/api/app.py
+++ b/ml/src/api/app.py
@@ -74,9 +74,19 @@ async def lifespan(app: FastAPI):
     if source_models:
         loaded = [k for k in source_models if k != "metadata"]
         version = source_models["metadata"].get("model_version", "?")
+        logger.info(
+            "Models loaded",
+            models=loaded,
+            version=version,
+            model_dir=os.path.abspath(MODEL_DIR),
+        )
     else:
         loaded = []
         version = None
+        logger.warning(
+            "No source models found at startup",
+            model_dir=os.path.abspath(MODEL_DIR),
+        )
 
     logger.info("Startup complete", source_models=loaded, version=version)
     yield
@@ -160,10 +170,18 @@ def maybe_reload_models(app_state) -> None:
         logger.info(
             "Model version changed — reloading all source models",
             old_version=app_state.model_version, new_version=current,
+            model_dir=os.path.abspath(app_state.model_dir),
         )
         app_state.models = load_source_models(app_state.model_dir)
         app_state.model_version = current
         app_state.data_cache = None  # Invalidate cached DataFrames
+        loaded = [k for k in app_state.models if k != "metadata"] if app_state.models else []
+        logger.info(
+            "Models reloaded",
+            models=loaded,
+            version=current,
+            model_dir=os.path.abspath(app_state.model_dir),
+        )
 
 
 # ── Cache functions ──────────────────────────────────────────────────
@@ -332,6 +350,12 @@ def predict(req: PredictRequest, request: Request):
 
     # 1. Check models loaded
     if not state.models:
+        logger.error(
+            "No source models loaded",
+            race_slug=req.race_slug,
+            year=req.year,
+            model_dir=os.path.abspath(MODEL_DIR),
+        )
         raise HTTPException(
             status_code=503,
             detail="No source models loaded. Run make retrain first.",
@@ -366,7 +390,18 @@ def predict(req: PredictRequest, request: Request):
     if race_info is None:
         if req.race_type:
             race_type = req.race_type
+            logger.info(
+                "Race not found in DB — using race_type from request",
+                race_slug=req.race_slug,
+                year=req.year,
+                race_type=race_type,
+            )
         else:
+            logger.warning(
+                "Race not found in DB and no race_type fallback provided",
+                race_slug=req.race_slug,
+                year=req.year,
+            )
             raise HTTPException(
                 status_code=404,
                 detail=f"Race not found: {req.race_slug}/{req.year}",
@@ -378,6 +413,11 @@ def predict(req: PredictRequest, request: Request):
     if race_type == 'classic':
         from ..prediction.classics import is_model_available, predict_classic_race
         if not is_model_available():
+            logger.error(
+                "Classic model not available",
+                race_slug=req.race_slug,
+                year=req.year,
+            )
             raise HTTPException(
                 status_code=404,
                 detail=f"Classic model not available for {req.race_slug}",
@@ -391,6 +431,12 @@ def predict(req: PredictRequest, request: Request):
             rider_ids=req.rider_ids,
         )
         if not predictions:
+            logger.warning(
+                "No predictions produced for classic race",
+                race_slug=req.race_slug,
+                year=req.year,
+                rider_count=len(req.rider_ids) if req.rider_ids else None,
+            )
             raise HTTPException(
                 status_code=404,
                 detail=f"No predictions for classic {req.race_slug}/{req.year}",
@@ -420,6 +466,13 @@ def predict(req: PredictRequest, request: Request):
     )
 
     if features_df.empty:
+        logger.warning(
+            "Empty features — no startlist or rider data for race",
+            race_slug=req.race_slug,
+            year=req.year,
+            race_type=race_type,
+            rider_count=len(req.rider_ids) if req.rider_ids else None,
+        )
         raise HTTPException(
             status_code=404,
             detail=f"No features for {req.race_slug}/{req.year} (no startlist?)",
@@ -466,6 +519,13 @@ def predict(req: PredictRequest, request: Request):
     )
 
     if not predictions:
+        logger.error(
+            "Prediction failed — predict_race_sources returned no results",
+            race_slug=req.race_slug,
+            year=req.year,
+            race_type=race_type,
+            rider_count=len(features_df),
+        )
         raise HTTPException(
             status_code=404,
             detail=f"Prediction failed for {req.race_slug}/{req.year}",

--- a/ml/src/training/retrain.py
+++ b/ml/src/training/retrain.py
@@ -11,15 +11,47 @@ Orchestrates the full source-by-source pipeline:
   7. Train all sub-models (source-by-source)
 
 Called via: make retrain  (which runs: cd ml && python -m src.retrain)
+
+Detached runs (e.g. `docker exec -d`) lose stdout/stderr, so this script
+also writes a tee'd log to `<cache>/retrain.log` and a `retrain_status.json`
+with exit code, duration, and any error so callers can verify the run.
 """
 
+import json
 import os
+import sys
 import time
+import traceback
+from datetime import datetime, timezone
 
 import pandas as pd
 
 from ..data.loader import load_data
-from ..features.stage_race import extract_all_training_features
+
+
+class _Tee:
+    """Mirror writes to multiple streams (stdout + log file)."""
+
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, data):
+        for s in self._streams:
+            s.write(data)
+            s.flush()
+
+    def flush(self):
+        for s in self._streams:
+            s.flush()
+
+
+def _write_status(cache_dir: str, payload: dict) -> None:
+    path = os.path.join(cache_dir, 'retrain_status.json')
+    try:
+        with open(path, 'w') as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+    except Exception as exc:
+        print(f"  WARNING: failed to write {path}: {exc}")
 
 
 def _synthesize_startlists(results_df: pd.DataFrame) -> pd.DataFrame:
@@ -36,16 +68,7 @@ def _synthesize_startlists(results_df: pd.DataFrame) -> pd.DataFrame:
     return sl
 
 
-def main():
-    db_url = os.environ.get(
-        'DATABASE_URL',
-        'postgresql://cycling:cycling@localhost:5432/cycling_analyzer',
-    )
-    model_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'models')
-    cache_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'cache')
-    os.makedirs(model_dir, exist_ok=True)
-    os.makedirs(cache_dir, exist_ok=True)
-
+def _run_pipeline(db_url: str, model_dir: str, cache_dir: str) -> dict:
     t0 = time.time()
     print("=" * 60)
     print("  Source-by-Source Retraining Pipeline")
@@ -132,6 +155,69 @@ def main():
     print(f"  Artifacts: {model_dir}")
     print(f"{'=' * 60}")
 
+    return {
+        'model_version': metadata.get('model_version'),
+        'duration_seconds': round(elapsed, 1),
+        'model_dir': os.path.abspath(model_dir),
+    }
+
+
+def main() -> int:
+    db_url = os.environ.get(
+        'DATABASE_URL',
+        'postgresql://cycling:cycling@localhost:5432/cycling_analyzer',
+    )
+    model_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'models')
+    cache_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'cache')
+    os.makedirs(model_dir, exist_ok=True)
+    os.makedirs(cache_dir, exist_ok=True)
+
+    started_at = datetime.now(timezone.utc).isoformat()
+    started_monotonic = time.time()
+    log_path = os.path.join(cache_dir, 'retrain.log')
+
+    # Tee stdout/stderr to retrain.log so detached runs leave a trace.
+    log_file = open(log_path, 'a', buffering=1)
+    log_file.write(f"\n\n===== retrain started at {started_at} =====\n")
+    original_stdout = sys.stdout
+    original_stderr = sys.stderr
+    sys.stdout = _Tee(original_stdout, log_file)
+    sys.stderr = _Tee(original_stderr, log_file)
+
+    status: dict = {
+        'started_at': started_at,
+        'log_path': os.path.abspath(log_path),
+    }
+
+    try:
+        result = _run_pipeline(db_url, model_dir, cache_dir)
+        status.update({
+            'status': 'success',
+            'exit_code': 0,
+            'completed_at': datetime.now(timezone.utc).isoformat(),
+            'duration_seconds': round(time.time() - started_monotonic, 1),
+            **result,
+        })
+        _write_status(cache_dir, status)
+        return 0
+    except Exception as exc:
+        tb = traceback.format_exc()
+        print(tb)
+        status.update({
+            'status': 'failed',
+            'exit_code': 1,
+            'completed_at': datetime.now(timezone.utc).isoformat(),
+            'duration_seconds': round(time.time() - started_monotonic, 1),
+            'error': f"{type(exc).__name__}: {exc}",
+            'traceback': tb,
+        })
+        _write_status(cache_dir, status)
+        return 1
+    finally:
+        sys.stdout = original_stdout
+        sys.stderr = original_stderr
+        log_file.close()
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #52. Closes the visibility gaps that turned production debugging into guesswork.

- **ML `/predict`**: structured warning/error logs at every early-return path (no models, race not found, classic unavailable, empty features, prediction failed) with `race_slug` / `year` / `rider_count` context.
- **ML startup + `maybe_reload_models`**: log loaded models with `model_dir`.
- **API `MlPredictionFailedError`**: logged at error level before throwing, with race / type / startlist size context. The previously empty `catch` in `MlScoringAdapter` now surfaces the underlying fetch exception with stack trace.
- **Retrain script**: tees stdout/stderr to `<cache>/retrain.log` and writes `<cache>/retrain_status.json` (status, exit_code, duration, model_version, or error/traceback) so detached `docker exec -d` runs leave a trace. Also propagates a non-zero exit code on failure.
- **Docs**: new "Detached / Background Runs" section in `docs/runbooks/retraining-runbook.md`.

## Test plan

- [x] `make lint`
- [x] API unit tests (466/466)
- [x] ML pytest (178/178)
- [x] `tsc --noEmit` for the API
- [ ] After merge: trigger a `make retrain` and confirm `retrain.log` and `retrain_status.json` appear in `ml/cache/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)