### PR TITLE
fix: use gRPC OTLP exporter for Tempo (Grafana Cloud recommended)

### DIFF
--- a/docs/runbooks/runbook-prod.md
+++ b/docs/runbooks/runbook-prod.md
@@ -219,7 +219,7 @@ Or filter by service across both containers in one query:
 **Common issues:**
 
 - **No data in Grafana Cloud after deploy**: check the Alloy container is running (`docker logs alloy` in the observability project). Bad credentials produce a clear error at startup.
-- **Logs flow but traces don't**: confirm `OTEL_EXPORTER_OTLP_ENDPOINT_API` / `OTEL_EXPORTER_OTLP_ENDPOINT_ML` are set on the cycling services and that `dokploy-network` resolves `alloy` (`docker exec cycling-api getent hosts alloy`).
+- **Logs flow but traces don't**: confirm `OTEL_EXPORTER_OTLP_ENDPOINT_API` / `OTEL_EXPORTER_OTLP_ENDPOINT_ML` are set on the cycling services and that `dokploy-network` resolves `alloy` (`docker exec cycling-api getent hosts alloy`). Also verify `GRAFANA_CLOUD_TEMPO_URL` is in `host:port` form with no `https://` prefix — Alloy uses gRPC for Tempo and a malformed URL will silently drop traces.
 - **Alloy crash-loops**: missing or wrong Grafana Cloud env vars, or token without `logs:write` / `traces:write` scopes. Recreate the Cloud Access Policy token with the correct scopes.
 
 ---

--- a/observability/.env.example
+++ b/observability/.env.example
@@ -7,8 +7,9 @@
 GRAFANA_CLOUD_LOKI_URL=https://logs-prod-XXX.grafana.net
 GRAFANA_CLOUD_LOKI_USER=000000
 
-# Tempo (traces)
-GRAFANA_CLOUD_TEMPO_URL=https://tempo-prod-XXX.grafana.net:443
+# Tempo (traces) — gRPC endpoint, NO https:// prefix, NO trailing path.
+# Format: <host>:<port>  e.g. tempo-prod-10-prod-eu-west-2.grafana.net:443
+GRAFANA_CLOUD_TEMPO_URL=tempo-prod-XX-prod-eu-west-N.grafana.net:443
 GRAFANA_CLOUD_TEMPO_USER=000000
 
 # Cloud Access Policy token (must have logs:write and traces:write scopes).

--- a/observability/README.md
+++ b/observability/README.md
@@ -25,7 +25,7 @@ Metrics are not collected yet — see issue #26 follow-ups.
 Inside your stack:
 
 - Click **"Send Logs"** on the Loki tile → copy the **URL** (e.g. `https://logs-prod-XXX.grafana.net`) and the **User** number.
-- Click **"Send Traces"** on the Tempo tile → copy the **URL** (e.g. `https://tempo-prod-XXX.grafana.net:443`) and the **User** number.
+- Click **"Send Traces"** on the Tempo tile → copy the **URL** but **strip the `https://` prefix and any trailing `/tempo` path**. Alloy uses gRPC for Tempo so the endpoint must be in the form `host:port`, e.g. `tempo-prod-10-prod-eu-west-2.grafana.net:443`. Also copy the **User** number (note: this is usually a different number than the Loki user).
 
 ### 3. Create a Cloud Access Policy token
 

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -3,10 +3,10 @@
 // dokploy-network and forwards them to Grafana Cloud (Loki + Tempo).
 //
 // Required environment variables (set in Dokploy, never commit values):
-//   GRAFANA_CLOUD_LOKI_URL    e.g. https://logs-prod-XXX.grafana.net
-//   GRAFANA_CLOUD_LOKI_USER   numeric instance ID
-//   GRAFANA_CLOUD_TEMPO_URL   e.g. https://tempo-prod-XXX.grafana.net:443
-//   GRAFANA_CLOUD_TEMPO_USER  numeric instance ID
+//   GRAFANA_CLOUD_LOKI_URL    e.g. https://logs-prod-XXX.grafana.net  (HTTPS, no path)
+//   GRAFANA_CLOUD_LOKI_USER   numeric instance ID for Loki
+//   GRAFANA_CLOUD_TEMPO_URL   e.g. tempo-prod-XX-prod-eu-west-N.grafana.net:443  (host:port, no scheme)
+//   GRAFANA_CLOUD_TEMPO_USER  numeric instance ID for Tempo (different from Loki!)
 //   GRAFANA_CLOUD_TOKEN       Cloud Access Policy token with logs:write + traces:write scopes
 
 // ---------------------------------------------------------------------------
@@ -70,7 +70,7 @@ otelcol.receiver.otlp "default" {
 
 otelcol.processor.batch "default" {
   output {
-    traces = [otelcol.exporter.otlphttp.grafana_cloud.input]
+    traces = [otelcol.exporter.otlp.grafana_cloud.input]
   }
 }
 
@@ -81,7 +81,9 @@ otelcol.auth.basic "grafana_cloud_tempo" {
   }
 }
 
-otelcol.exporter.otlphttp "grafana_cloud" {
+// Use the gRPC OTLP exporter (not HTTP) — this matches what Grafana Cloud
+// recommends for Tempo. The endpoint is `host:port` without a scheme.
+otelcol.exporter.otlp "grafana_cloud" {
   client {
     endpoint = sys.env("GRAFANA_CLOUD_TEMPO_URL")
     auth     = otelcol.auth.basic.grafana_cloud_tempo.handler


### PR DESCRIPTION
## Summary
- Switch from `otelcol.exporter.otlphttp` to `otelcol.exporter.otlp` (gRPC) for Tempo
- The Grafana Cloud Tempo "Send Traces" portal page generates an Alloy snippet using gRPC with a `host:port` endpoint (no `https://` prefix, no `/otlp` path), so I'm aligning the config with the official recommendation
- Updates env example, README, and runbook to make the URL format explicit

## Why
While going through the Grafana Cloud setup with the user, the actual Tempo "Send Traces" page generated this snippet:

```alloy
otelcol.exporter.otlp "grafanacloud" {
  client {
    endpoint = "tempo-prod-10-prod-eu-west-2.grafana.net:443"
    auth     = otelcol.auth.basic.grafanacloud.handler
  }
}
```

Note `otelcol.exporter.otlp` (not `otelcol.exporter.otlphttp`) and the bare `host:port` endpoint. Better match the official recommendation than risk silent trace drops.

## Test plan
- [x] `make lint` passes
- [ ] Deploy and verify traces reach Grafana Cloud Tempo

🤖 Generated with [Claude Code](https://claude.com/claude-code)