### PR TITLE
fix: use top-level username/password in otelcol.auth.basic

### DIFF
--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -75,10 +75,8 @@ otelcol.processor.batch "default" {
 }
 
 otelcol.auth.basic "grafana_cloud_tempo" {
-  client_auth {
-    username = sys.env("GRAFANA_CLOUD_TEMPO_USER")
-    password = sys.env("GRAFANA_CLOUD_TOKEN")
-  }
+  username = sys.env("GRAFANA_CLOUD_TEMPO_USER")
+  password = sys.env("GRAFANA_CLOUD_TOKEN")
 }
 
 // Use the gRPC OTLP exporter (not HTTP) — this matches what Grafana Cloud


### PR DESCRIPTION
## Summary
- Alloy v1.4 rejects the \`client_auth\` block inside \`otelcol.auth.basic\` (\`unrecognized block name "client_auth"\`)
- Revert to the top-level \`username\`/\`password\` form, which is what the Grafana Cloud Tempo "Send Traces" page actually generates

## Why this happened
The earlier PR #62 wrapped the credentials in a \`client_auth\` block based on an outdated doc snippet. The actual production config that Grafana Cloud generates uses top-level fields. Alloy logs at startup:

\`\`\`
Error: /etc/alloy/config.alloy:78:3: unrecognized block name "client_auth"
\`\`\`

## Test plan
- [ ] Redeploy observability project in Dokploy and verify Alloy reaches \`Status: healthy\` instead of crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)