### PR TITLE
fix(ml): refresh startlist on-demand when missing from cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ ML-powered fantasy cycling team optimizer for [Grandes miniVueltas](https://gran
 - Training pipelines in `ml/src/training/`.
 - Structured logging with structlog; correlation IDs via asgi-correlation-id.
 - Models saved as joblib in `ml/models/` (gitignored).
+- **Data cache is a lazy in-memory snapshot.** `state.data_cache` (results_df + startlists_df) is loaded from the DB on the first `/predict` request and only invalidated on model hot-reload. The API scrapes fresh startlists into `startlist_entries` right before calling ML, so for the newly-requested race the `/predict` handler must query the DB on-demand via `load_startlist_for_race()` and merge the result into the cached DataFrame. Any new table that the API writes to between ML requests needs the same treatment — don't assume the cache is in sync with the DB.
 
 ## Dependencies & Commands
 

--- a/ml/src/api/app.py
+++ b/ml/src/api/app.py
@@ -26,7 +26,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from ..data.loader import get_race_info, load_data
+from ..data.loader import get_race_info, load_data, load_startlist_for_race
 from ..features.stage_race import FEATURE_COLS, extract_features_for_race
 from .logging_config import configure_logging
 from .model_version import get_model_version
@@ -381,6 +381,36 @@ def predict(req: PredictRequest, request: Request):
         state.data_cache = (results_df, startlists_df, supply_hist, completion, sprint_ped)
     else:
         results_df, startlists_df, supply_hist, completion, sprint_ped = state.data_cache
+
+    # Refresh the startlist for the requested race on-demand.
+    # The cached `startlists_df` is a snapshot taken at the first request and is
+    # never invalidated afterwards, so freshly-scraped startlists (e.g. the API
+    # persists a new startlist for an upcoming race right before this call) are
+    # invisible to predictions. Query the DB for this specific (race_slug, year)
+    # and merge it into the cached DataFrame if we don't already have it.
+    has_startlist = not startlists_df[
+        (startlists_df["race_slug"] == req.race_slug)
+        & (startlists_df["year"] == req.year)
+    ].empty
+    if not has_startlist:
+        fresh_sl = load_startlist_for_race(DB_URL, req.race_slug, req.year)
+        if not fresh_sl.empty:
+            logger.info(
+                "Loaded fresh startlist for race not in cache",
+                race_slug=req.race_slug,
+                year=req.year,
+                rider_count=len(fresh_sl),
+            )
+            startlists_df = pd.concat([startlists_df, fresh_sl], ignore_index=True)
+            # Persist back into the cache so subsequent requests for the same
+            # race don't re-query the DB.
+            state.data_cache = (
+                results_df,
+                startlists_df,
+                supply_hist,
+                completion,
+                sprint_ped,
+            )
 
     # Get race info — always use today as cutoff so predictions reflect
     # the latest available data (treat every race as "future").

--- a/ml/tests/test_app.py
+++ b/ml/tests/test_app.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 from starlette.testclient import TestClient
 
@@ -65,3 +66,106 @@ class TestPredictEndpoint:
         )
         assert resp.status_code == 503
         assert 'No source models loaded' in resp.json()['detail']
+
+    def test_predict_refreshes_startlist_when_missing_from_cache(self, client_with_model):
+        """Regression: the in-memory startlists_df is a snapshot taken at first
+        request and never invalidated. When the API scrapes a new startlist
+        (e.g. for an upcoming race like paris-roubaix/2026) and then calls the
+        ML service, the cached DataFrame does not contain that race yet, so
+        predictions used to silently fail with "No riders found".
+
+        The fix queries the DB on-demand for the requested (race_slug, year)
+        and merges the result into the cached DataFrame before running the
+        prediction pipeline.
+        """
+        # Cached snapshot with no row for the requested race
+        empty_startlists = pd.DataFrame(
+            columns=['race_slug', 'year', 'rider_id', 'team_name']
+        )
+        app.state.data_cache = (
+            pd.DataFrame(),  # results_df
+            empty_startlists,
+            {},  # supply_hist
+            {},  # completion
+            {},  # sprint_pedigree
+        )
+
+        # Freshly scraped startlist that lives only in the DB, not in the cache
+        fresh_startlist = pd.DataFrame(
+            [
+                {
+                    'race_slug': 'paris-roubaix',
+                    'year': 2026,
+                    'rider_id': 'rider-42',
+                    'team_name': 'Team X',
+                }
+            ]
+        )
+
+        with patch(
+            'src.api.app.load_startlist_for_race', return_value=fresh_startlist
+        ) as mock_load_sl, patch(
+            'src.api.app.get_race_info', return_value=None
+        ):
+            # get_race_info returns None and we don't pass race_type, so the
+            # endpoint short-circuits to 404 after the refresh step. That's
+            # enough to verify the refresh fired with the correct arguments
+            # without needing to mock the full classics/stage-race pipeline.
+            resp = client_with_model.post(
+                '/predict',
+                json={'race_slug': 'paris-roubaix', 'year': 2026},
+            )
+
+        mock_load_sl.assert_called_once()
+        args, _ = mock_load_sl.call_args
+        assert args[1] == 'paris-roubaix'
+        assert args[2] == 2026
+
+        # The cache must be updated in-place so later requests don't re-query.
+        _, cached_startlists, *_ = app.state.data_cache
+        merged = cached_startlists[
+            (cached_startlists['race_slug'] == 'paris-roubaix')
+            & (cached_startlists['year'] == 2026)
+        ]
+        assert len(merged) == 1
+        assert merged.iloc[0]['rider_id'] == 'rider-42'
+
+        # The request itself returns 404 because we short-circuited get_race_info;
+        # the point of this test is the refresh side-effect, not the outcome.
+        assert resp.status_code == 404
+
+    def test_predict_does_not_refetch_startlist_when_already_in_cache(
+        self, client_with_model
+    ):
+        """If the requested race is already present in the cached snapshot we
+        must NOT hit the DB again — the refresh path is strictly for cache
+        misses."""
+        cached_startlists = pd.DataFrame(
+            [
+                {
+                    'race_slug': 'tour-de-france',
+                    'year': 2025,
+                    'rider_id': 'rider-1',
+                    'team_name': 'Team Y',
+                }
+            ]
+        )
+        app.state.data_cache = (
+            pd.DataFrame(),
+            cached_startlists,
+            {},
+            {},
+            {},
+        )
+
+        with patch(
+            'src.api.app.load_startlist_for_race'
+        ) as mock_load_sl, patch(
+            'src.api.app.get_race_info', return_value=None
+        ):
+            client_with_model.post(
+                '/predict',
+                json={'race_slug': 'tour-de-france', 'year': 2025},
+            )
+
+        mock_load_sl.assert_not_called()


### PR DESCRIPTION
## Summary

- The ML service's `state.data_cache` (results_df + startlists_df) was lazily loaded on the first `/predict` call and only invalidated on model hot-reload. Any startlist scraped by the API **after** that first call was invisible to the ML service, so analyzing a newly-added race (e.g. Paris-Roubaix 2026) failed with `No riders found for paris-roubaix/2026`.
- The `/predict` handler now checks whether the requested `(race_slug, year)` is in the cached DataFrame and, if not, queries the DB on-demand via the pre-existing `load_startlist_for_race()` helper and merges the result into the cache.
- Added two regression tests and documented the in-memory-cache gotcha in `AGENTS.md`.

## Context

This reversed the intent of 9b3c0a6 (`fix: use PCS startlist instead of synthetic riderIds for ML predictions`). That commit stopped the NestJS API from sending synthetic `rider_ids` and made the ML service the source of truth, under the assumption that the ML service read startlists from the DB on each call. It doesn't — it reads from a frozen in-memory snapshot.

Stage races happened to work in production because the races users analyze were already in the initial DB seed when the ML cache first warmed up. Newly-scraped races (classics or stage) hit this bug equally; Paris-Roubaix 2026 was the first to surface it because it was added after ML startup.

## Test plan

- [x] `cd ml && pytest` — 180 passed (includes 2 new regression tests)
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] `make test` (API) — 466 passed
- [ ] Smoke test on prod after merge: trigger analyse for `paris-roubaix/2026` and confirm predictions come back

🤖 Generated with [Claude Code](https://claude.com/claude-code)