### PR TITLE
fix(ml): log failed /predict paths at error level

### DIFF
--- a/ml/src/api/app.py
+++ b/ml/src/api/app.py
@@ -427,7 +427,7 @@ def predict(req: PredictRequest, request: Request):
                 race_type=race_type,
             )
         else:
-            logger.warning(
+            logger.error(
                 "Race not found in DB and no race_type fallback provided",
                 race_slug=req.race_slug,
                 year=req.year,
@@ -461,7 +461,7 @@ def predict(req: PredictRequest, request: Request):
             rider_ids=req.rider_ids,
         )
         if not predictions:
-            logger.warning(
+            logger.error(
                 "No predictions produced for classic race",
                 race_slug=req.race_slug,
                 year=req.year,
@@ -496,7 +496,7 @@ def predict(req: PredictRequest, request: Request):
     )
 
     if features_df.empty:
-        logger.warning(
+        logger.error(
             "Empty features — no startlist or rider data for race",
             race_slug=req.race_slug,
             year=req.year,

--- a/ml/src/prediction/classics.py
+++ b/ml/src/prediction/classics.py
@@ -143,7 +143,7 @@ def predict_classic_race(
             target_rider_ids = race_results["rider_id"].unique().tolist()
 
     if not target_rider_ids:
-        logger.warning("No riders found for %s/%s", race_slug, year)
+        logger.error("No riders found for %s/%s", race_slug, year)
         return []
 
     # Get rider names from results (for response)


### PR DESCRIPTION
## Summary

Four log sites in the ML service currently emit `logger.warning` but all terminate the request with `HTTPException(404)`, which NestJS surfaces to the end user as `MlPredictionFailedError`. These are operation failures on our side — the 404 is just the protocol shape we picked, not a client-side problem. At warn level they were invisible to any production alerting keyed on `level=error`.

Promoted to `logger.error`:

| File | Message |
|---|---|
| `ml/src/prediction/classics.py` | `No riders found for <slug>/<year>` |
| `ml/src/api/app.py` | `Race not found in DB and no race_type fallback provided` |
| `ml/src/api/app.py` | `No predictions produced for classic race` |
| `ml/src/api/app.py` | `Empty features — no startlist or rider data for race` |

## Context

Follow-up to #66: while debugging the Paris-Roubaix 2026 stale-startlist bug we noticed these were showing up as WARN in Loki, which meant they never hit the error dashboards. Paris-Roubaix specifically logged the first and third of the four — but all four share the same pattern and deserve the same treatment for consistency and observability.

The rule applied: anything that ends in a `raise HTTPException` from a handler because **we** couldn't do our job (data gap, missing model inputs) is ERROR, even if the HTTP response is a 4xx.

## Test plan

- [x] `cd ml && pytest` — 180 passed (no test asserts log level but wanted to catch any import breakage)
- [ ] After merge: trigger a failure case on the staging/prod ML service and confirm the log entry shows up at `level=error` in Loki / Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)