### PR TITLE
fix(security): enforce hostname allow-list on scraping REST endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,9 @@ make dev           # starts all services
 
 ## Security Rules
 
-- **Scraping operations are CLI/cron only** — never expose scraping behind REST endpoints.
+- **Bulk / historical scraping is CLI/cron only.** Seeding the database with historical race results, weekly retraining ingestion, and any multi-race batch scrape must run from `presentation/cli/` or a Dokploy scheduled task — never behind a REST endpoint. These flows iterate over many races and would be trivially abusable if exposed publicly.
+- **On-demand per-race scraping is allowed from REST endpoints**, because it is the core product flow: when the user picks the race they are about to analyze, the API fetches that race's startlist, stage profile, and the GMV price list at request time. Allowed endpoints today: `GET /api/race-profile`, `GET /api/race-profile-by-slug`, `GET /api/import-price-list`, and the startlist fetch inside `POST /api/analyze`.
+- **Any REST endpoint that performs an outbound fetch from a user-supplied URL must enforce a hostname allow-list** (`grandesminivueltas.com` for price lists, `procyclingstats.com` for race/profile pages). Parse with `new URL(...)`, compare `.hostname`, and reject anything else with `BadRequestException` at the controller boundary. Never rely on substring checks like `url.includes('…')` — they are trivially bypassable (`http://169.254.169.254/?procyclingstats.com/race/x/2024`).
 - Never commit `.env`, `.env.local`, credentials, or API keys.
 - Validate all external input at system boundaries (controllers, API endpoints).
 

--- a/apps/api/src/presentation/__tests__/analyze.controller.spec.ts
+++ b/apps/api/src/presentation/__tests__/analyze.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 import { AnalyzeController } from '../analyze.controller';
 import {
   AnalyzePriceListUseCase,
@@ -9,6 +10,7 @@ import { ImportPriceListUseCase } from '../../application/analyze/import-price-l
 describe('AnalyzeController', () => {
   let controller: AnalyzeController;
   let mockUseCase: jest.Mocked<Pick<AnalyzePriceListUseCase, 'execute'>>;
+  let mockImportUseCase: jest.Mocked<Pick<ImportPriceListUseCase, 'execute'>>;
 
   const sampleResponse: AnalyzeResponse = {
     riders: [
@@ -43,12 +45,15 @@ describe('AnalyzeController', () => {
     mockUseCase = {
       execute: jest.fn().mockResolvedValue(sampleResponse),
     };
+    mockImportUseCase = {
+      execute: jest.fn().mockResolvedValue({ riders: [] }),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AnalyzeController],
       providers: [
         { provide: AnalyzePriceListUseCase, useValue: mockUseCase },
-        { provide: ImportPriceListUseCase, useValue: { execute: jest.fn() } },
+        { provide: ImportPriceListUseCase, useValue: mockImportUseCase },
       ],
     }).compile();
 
@@ -94,5 +99,43 @@ describe('AnalyzeController', () => {
     // The result event should have been written to the stream
     const resultEvent = written.find((w) => w.startsWith('event: result'));
     expect(resultEvent).toBeDefined();
+  });
+
+  describe('importPriceList', () => {
+    it('accepts the GMV price list URL', async () => {
+      await controller.importPriceList('https://grandesminivueltas.com/precios/2026');
+      expect(mockImportUseCase.execute).toHaveBeenCalledWith(
+        'https://grandesminivueltas.com/precios/2026',
+      );
+    });
+
+    it('accepts GMV subdomains', async () => {
+      await controller.importPriceList('https://www.grandesminivueltas.com/precios/2026');
+      expect(mockImportUseCase.execute).toHaveBeenCalled();
+    });
+
+    it('rejects a missing URL', async () => {
+      await expect(controller.importPriceList('')).rejects.toThrow(BadRequestException);
+      expect(mockImportUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['localhost', 'http://localhost/precios'],
+      ['loopback', 'http://127.0.0.1/precios'],
+      ['private network', 'http://10.0.0.1/precios'],
+      ['Docker service', 'http://postgres:5432/'],
+      ['metadata IP', 'http://169.254.169.254/latest/meta-data/'],
+      [
+        'metadata IP with grandesminivueltas substring bypass',
+        'http://169.254.169.254/?grandesminivueltas.com/precios',
+      ],
+      ['credentials bypass', 'https://grandesminivueltas.com@evil.com/precios'],
+      ['wrong protocol', 'file:///etc/passwd'],
+      ['unrelated host', 'https://evil.com/precios'],
+      ['look-alike host', 'https://evilgrandesminivueltas.com/precios'],
+    ])('rejects SSRF payload (%s)', async (_label, url) => {
+      await expect(controller.importPriceList(url)).rejects.toThrow(BadRequestException);
+      expect(mockImportUseCase.execute).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/presentation/__tests__/race-profile.controller.spec.ts
+++ b/apps/api/src/presentation/__tests__/race-profile.controller.spec.ts
@@ -84,6 +84,23 @@ describe('RaceProfileController', () => {
     expect(mockUseCase.execute).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['localhost', 'http://localhost/race/x/2024'],
+    ['loopback', 'http://127.0.0.1/race/x/2024'],
+    ['private network', 'http://10.0.0.1/race/x/2024'],
+    ['metadata IP', 'http://169.254.169.254/latest/meta-data/'],
+    [
+      'metadata IP with procyclingstats substring bypass',
+      'http://169.254.169.254/?procyclingstats.com/race/x/2024',
+    ],
+    ['credentials bypass', 'https://www.procyclingstats.com@evil.com/race/x/2024'],
+    ['wrong protocol', 'file:///etc/passwd'],
+    ['look-alike host', 'https://evilprocyclingstats.com/race/x/2024'],
+  ])('rejects SSRF payload (%s)', async (_label, url) => {
+    await expect(controller.getRaceProfile(url)).rejects.toThrow(BadRequestException);
+    expect(mockUseCase.execute).not.toHaveBeenCalled();
+  });
+
   it('should propagate NotFoundException from use case', async () => {
     mockUseCase.execute.mockRejectedValueOnce(new NotFoundException('Could not determine profile'));
 

--- a/apps/api/src/presentation/analyze.controller.ts
+++ b/apps/api/src/presentation/analyze.controller.ts
@@ -28,6 +28,9 @@ import {
 } from '../domain/analyze/errors';
 import type { AnalysisStepId } from '@cycling-analyzer/shared-types';
 import { SseProgressNotifier } from './sse-progress-notifier';
+import { assertAllowedHost } from './validation/assert-allowed-host';
+
+const PRICE_LIST_ALLOWED_HOSTS = ['grandesminivueltas.com'];
 
 class PriceListEntryDto {
   @IsString()
@@ -172,6 +175,7 @@ export class AnalyzeController {
       throw new BadRequestException('url query parameter is required');
     }
 
+    assertAllowedHost(trimmedUrl, PRICE_LIST_ALLOWED_HOSTS);
     return this.importPriceListUseCase.execute(trimmedUrl);
   }
 }

--- a/apps/api/src/presentation/race-profile.controller.ts
+++ b/apps/api/src/presentation/race-profile.controller.ts
@@ -1,6 +1,9 @@
 import { Controller, Get, Query, BadRequestException } from '@nestjs/common';
 import { FetchRaceProfileUseCase } from '../application/analyze/fetch-race-profile.use-case';
 import type { RaceProfileResponse } from '@cycling-analyzer/shared-types';
+import { assertAllowedHost } from './validation/assert-allowed-host';
+
+const PCS_ALLOWED_HOSTS = ['procyclingstats.com'];
 
 @Controller('api')
 export class RaceProfileController {
@@ -8,9 +11,10 @@ export class RaceProfileController {
 
   @Get('race-profile')
   async getRaceProfile(@Query('url') url: string): Promise<RaceProfileResponse> {
-    if (!url || !url.includes('procyclingstats.com/race/')) {
-      throw new BadRequestException('Invalid PCS race URL');
+    if (!url) {
+      throw new BadRequestException('url query parameter is required');
     }
+    assertAllowedHost(url, PCS_ALLOWED_HOSTS);
     return this.fetchRaceProfile.execute(url);
   }
 }

--- a/apps/api/src/presentation/validation/__tests__/assert-allowed-host.spec.ts
+++ b/apps/api/src/presentation/validation/__tests__/assert-allowed-host.spec.ts
@@ -1,0 +1,86 @@
+import { BadRequestException } from '@nestjs/common';
+import { assertAllowedHost } from '../assert-allowed-host';
+
+describe('assertAllowedHost', () => {
+  const allowed = ['procyclingstats.com'];
+
+  it('accepts an exact allowed host', () => {
+    const url = assertAllowedHost('https://procyclingstats.com/race/x/2024', allowed);
+    expect(url.hostname).toBe('procyclingstats.com');
+  });
+
+  it('accepts subdomains of an allowed host', () => {
+    const url = assertAllowedHost('https://www.procyclingstats.com/race/x/2024', allowed);
+    expect(url.hostname).toBe('www.procyclingstats.com');
+  });
+
+  it('is case-insensitive on the hostname', () => {
+    const url = assertAllowedHost('https://WWW.ProCyclingStats.com/race/x/2024', allowed);
+    expect(url.hostname).toBe('www.procyclingstats.com');
+  });
+
+  it('rejects an empty or malformed URL', () => {
+    expect(() => assertAllowedHost('', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('not a url', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('procyclingstats.com/race/x', allowed)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects non-http(s) protocols', () => {
+    expect(() => assertAllowedHost('file:///etc/passwd', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('ftp://procyclingstats.com/', allowed)).toThrow(
+      BadRequestException,
+    );
+    expect(() => assertAllowedHost('javascript:alert(1)', allowed)).toThrow(BadRequestException);
+  });
+
+  it('rejects URLs with embedded credentials', () => {
+    expect(() =>
+      assertAllowedHost('https://procyclingstats.com@evil.com/race/x/2024', allowed),
+    ).toThrow(BadRequestException);
+    expect(() =>
+      assertAllowedHost('https://user:pass@procyclingstats.com/race/x/2024', allowed),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects localhost and loopback addresses', () => {
+    expect(() => assertAllowedHost('http://localhost/', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('http://127.0.0.1/', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('http://[::1]/', allowed)).toThrow(BadRequestException);
+  });
+
+  it('rejects private network and metadata IPs', () => {
+    expect(() => assertAllowedHost('http://10.0.0.1/', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('http://192.168.1.1/', allowed)).toThrow(BadRequestException);
+    expect(() => assertAllowedHost('http://169.254.169.254/latest/meta-data/', allowed)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects the substring-check bypass payload from the SSRF report', () => {
+    expect(() =>
+      assertAllowedHost('http://169.254.169.254/?procyclingstats.com/race/x/2024', allowed),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects hosts that merely contain an allowed suffix as a substring', () => {
+    expect(() => assertAllowedHost('https://evilprocyclingstats.com/race/x/2024', allowed)).toThrow(
+      BadRequestException,
+    );
+    expect(() =>
+      assertAllowedHost('https://procyclingstats.com.evil.com/race/x/2024', allowed),
+    ).toThrow(BadRequestException);
+  });
+
+  it('supports multiple allow-list entries', () => {
+    const multi = ['grandesminivueltas.com', 'procyclingstats.com'];
+    expect(assertAllowedHost('https://grandesminivueltas.com/prices', multi).hostname).toBe(
+      'grandesminivueltas.com',
+    );
+    expect(assertAllowedHost('https://www.procyclingstats.com/', multi).hostname).toBe(
+      'www.procyclingstats.com',
+    );
+    expect(() => assertAllowedHost('https://example.com/', multi)).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/presentation/validation/assert-allowed-host.ts
+++ b/apps/api/src/presentation/validation/assert-allowed-host.ts
@@ -1,0 +1,27 @@
+import { BadRequestException } from '@nestjs/common';
+
+export function assertAllowedHost(rawUrl: string, allowedSuffixes: string[]): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new BadRequestException('Invalid URL');
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new BadRequestException('Only http(s) URLs are allowed');
+  }
+
+  // Reject credentials in the authority — blocks bypasses like https://allowed.com@evil.com
+  if (parsed.username !== '' || parsed.password !== '') {
+    throw new BadRequestException('URL must not contain credentials');
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const allowed = allowedSuffixes.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+  if (!allowed) {
+    throw new BadRequestException(`Host ${host} is not allowed`);
+  }
+
+  return parsed;
+}

--- a/docs/adr/2026-03-15-two-scraper-strategies.md
+++ b/docs/adr/2026-03-15-two-scraper-strategies.md
@@ -9,7 +9,12 @@ The application scrapes rider and race result data from ProCyclingStats (PCS). P
 
 ## Decision
 
-We implemented scraping behind a port interface (`ScraperPort`) with support for multiple strategy implementations. The primary strategy uses Cheerio for HTML parsing. Strategies are registered with the infrastructure layer and selected based on health status. Scraping is restricted to CLI commands and scheduled cron jobs — no REST endpoints trigger scrapes.
+We implemented scraping behind a port interface (`ScraperPort`) with support for multiple strategy implementations. The primary strategy uses Cheerio for HTML parsing. Strategies are registered with the infrastructure layer and selected based on health status.
+
+Two scraping modes coexist with different exposure rules:
+
+- **Bulk / historical scraping** (database seeding, weekly retraining ingestion) is restricted to CLI commands and scheduled cron jobs. No REST endpoint triggers a batch scrape.
+- **On-demand per-race scraping** (startlist, stage profile, and price list for the single race the user is currently analyzing) is reached from public REST endpoints because it is the core product flow. These endpoints MUST enforce a hostname allow-list on any user-supplied URL (`procyclingstats.com`, `grandesminivueltas.com`) to prevent SSRF.
 
 ## Consequences
 
@@ -18,7 +23,8 @@ We implemented scraping behind a port interface (`ScraperPort`) with support for
 - Resilient to site structure changes: if one strategy breaks, others can take over
 - Easy to add new scraper implementations without modifying existing code
 - Port interface makes scraping fully testable with stub implementations
-- CLI-only execution prevents abuse via public API endpoints
+- Bulk scraping is CLI-only, preventing abuse of expensive multi-race jobs via public API
+- On-demand scraping is allow-listed at the hostname level, preventing SSRF into `dokploy-network`
 
 ### Negative
 

--- a/docs/runbooks/runbook-prod.md
+++ b/docs/runbooks/runbook-prod.md
@@ -140,11 +140,21 @@ DELETE FROM ml_scores WHERE race_slug = 'tour-de-france' AND year = 2026;
 
 ### Scraping
 
-Scraping operations are CLI-only. No REST endpoints are exposed for scraping (security policy).
+The system has two distinct scraping modes. They have different security policies — do not conflate them.
+
+**Bulk / historical scraping (CLI/cron only).** Seeding the database with years of historical results and the weekly retraining ingestion are CLI-only. They must never be triggered by a REST endpoint.
 
 - Initial data population runs via the `seed-database` CLI command (see above)
-- Production scraping should be scheduled via Dokploy scheduled tasks, not run ad-hoc
+- Production bulk scraping runs via Dokploy scheduled tasks (`./scripts/weekly-pipeline.sh`), not ad-hoc
 - Configure scheduled tasks in Dokploy > Project > Scheduled Tasks
+
+**On-demand per-race scraping (REST, allow-listed).** When a user selects the race they are about to analyze, the API fetches that single race's startlist, stage profile, and the GMV price list at request time. This is the core product flow and runs from public REST endpoints:
+
+- `GET /api/race-profile` / `GET /api/race-profile-by-slug` — PCS stage profiles
+- `GET /api/import-price-list` — GMV rider prices
+- Startlist fetch inside `POST /api/analyze`
+
+All three are restricted by hostname allow-list (`procyclingstats.com`, `grandesminivueltas.com`) to prevent SSRF. Substring checks on the URL are not acceptable — use `new URL(...).hostname`.
 
 ---
 
@@ -298,7 +308,8 @@ Or filter by service across both containers in one query:
 | SSH                | Key-only authentication, no root login                             |
 | Firewall           | Only ports 22, 80, 443, 3000 (Dokploy dashboard) open              |
 | Containers         | Run as non-root (UID 1001)                                         |
-| Scraping endpoints | None exposed publicly — CLI/cron only                              |
+| Bulk scraping      | CLI/cron only — no REST endpoint triggers batch scrapes            |
+| On-demand scraping | REST endpoints restricted by hostname allow-list (PCS, GMV)        |
 | Database           | Not exposed publicly — accessible only via internal Docker network |
 | Secrets            | Managed via Dokploy environment variables, not committed to repo   |
 | OS updates         | Applied monthly on VPS                                             |


### PR DESCRIPTION
Closes #68.

## Summary

- **`GET /api/import-price-list` had a real SSRF.** The raw `url` query param was passed straight to `gotScraping`, so the public API could be used to reach internal services on `dokploy-network` (postgres, otelcol, alloy) or as an anonymizing proxy.
- **`GET /api/race-profile` had misleading defense.** The substring check `url.includes('procyclingstats.com/race/')` is trivially bypassable (`http://169.254.169.254/?procyclingstats.com/race/x/2024`). The actual fetch was safe today only because `FetchRaceProfileUseCase` rebuilds the URL from a hardcoded base — fragile, breaks silently on refactor.
- Both endpoints now validate user-supplied URLs through a shared `assertAllowedHost` helper that parses with `new URL(...)`, rejects non-http(s) protocols, rejects embedded credentials (`https://allowed.com@evil.com` bypass), and compares `.hostname` against an allow-list (`grandesminivueltas.com` / `procyclingstats.com`, subdomains included).
- Docs updated (`AGENTS.md`, `docs/runbooks/runbook-prod.md`, `docs/adr/2026-03-15-two-scraper-strategies.md`) to distinguish **bulk/historical scraping** (CLI/cron only) from **on-demand per-race scraping** (REST with hostname allow-list). The old wording was being misread as forbidding the product's core import flow.

## What I did NOT do

- Did not remove the endpoints. They back the core product flow (user picks a race → API fetches that race's startlist + stage profile + price list at request time). Removing them would mean redesigning the import UX, which is out of scope here.
- Did not touch the other two open security issues (#69 rate limiting, #70 CORS/helmet). Separate PRs.

## Test plan

- [x] `npx jest` in `apps/api` — 498 tests pass
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] New unit tests for `assertAllowedHost` cover: exact host, subdomains, case-insensitivity, malformed URLs, non-http(s) protocols, credentials bypass, localhost/loopback/IPv6, private network IPs, metadata IP, substring-check bypass payload from the issue, look-alike hosts (`evilprocyclingstats.com`, `procyclingstats.com.evil.com`), multiple allow-list entries
- [x] New controller tests parametrize the same bypass payloads against `/api/race-profile` and `/api/import-price-list`
- [ ] Manual smoke in local dev after merge: `curl 'http://localhost:3001/api/import-price-list?url=http://localhost/'` → 400; `curl '.../api/race-profile?url=https://www.procyclingstats.com/race/tour-de-france/2025'` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)