### PR TITLE
fix(security): fail-fast on missing CORS_ORIGIN in prod and add helmet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ DATABASE_URL=postgresql://cycling:cycling@localhost:5432/cycling_analyzer
 # API
 PORT=3001
 NODE_ENV=development
+# CORS_ORIGIN is required when NODE_ENV=production. In dev the API falls back
+# to http://localhost:3000 if unset.
+# CORS_ORIGIN=http://localhost:3000
 
 # PCS scraping
 PCS_REQUEST_DELAY_MS=1500

--- a/README.md
+++ b/README.md
@@ -42,18 +42,18 @@ The API uses `@nestjs/config` to load env files with this priority:
 
 Both are optional. If neither exists, built-in defaults apply.
 
-| Variable                      | Default                                                        | Description                                                         |
-| ----------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `DATABASE_URL`                | `postgresql://cycling:cycling@localhost:5432/cycling_analyzer` | PostgreSQL connection string                                        |
-| `PORT`                        | `3001`                                                         | API server port                                                     |
-| `CORS_ORIGIN`                 | `http://localhost:3000`                                        | Allowed CORS origin for the frontend                                |
-| `PCS_REQUEST_DELAY_MS`        | `1500`                                                         | Delay between PCS scrape requests                                   |
-| `FUZZY_MATCH_THRESHOLD`       | `-10000`                                                       | Minimum score for fuzzy rider name matching                         |
-| `ML_SERVICE_URL`              | `http://localhost:8000`                                        | ML scoring microservice URL                                         |
-| `VITE_API_URL`                | `http://localhost:3001`                                        | API URL for the frontend (build-time)                               |
-| `LOG_LEVEL`                   | `info` (prod) / `debug` (dev)                                  | Log level for API and ML service                                    |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(disabled)_                                                   | OTLP collector URL — enables distributed tracing                    |
-| `THROTTLE_DISABLE`            | _(unset)_                                                      | Set to `true` to bypass rate limiting (CI/E2E only — never in prod) |
+| Variable                      | Default                                                        | Description                                                                                                     |
+| ----------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `DATABASE_URL`                | `postgresql://cycling:cycling@localhost:5432/cycling_analyzer` | PostgreSQL connection string                                                                                    |
+| `PORT`                        | `3001`                                                         | API server port                                                                                                 |
+| `CORS_ORIGIN`                 | `http://localhost:3000`                                        | Allowed CORS origin for the frontend. **Required** when `NODE_ENV=production` — API crashes on boot if missing. |
+| `PCS_REQUEST_DELAY_MS`        | `1500`                                                         | Delay between PCS scrape requests                                                                               |
+| `FUZZY_MATCH_THRESHOLD`       | `-10000`                                                       | Minimum score for fuzzy rider name matching                                                                     |
+| `ML_SERVICE_URL`              | `http://localhost:8000`                                        | ML scoring microservice URL                                                                                     |
+| `VITE_API_URL`                | `http://localhost:3001`                                        | API URL for the frontend (build-time)                                                                           |
+| `LOG_LEVEL`                   | `info` (prod) / `debug` (dev)                                  | Log level for API and ML service                                                                                |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | _(disabled)_                                                   | OTLP collector URL — enables distributed tracing                                                                |
+| `THROTTLE_DISABLE`            | _(unset)_                                                      | Set to `true` to bypass rate limiting (CI/E2E only — never in prod)                                             |
 
 > **Note:** If you have a `DATABASE_URL` already exported in your shell (e.g. from another project), it will take precedence over `.env` files. Use `.env.local` or `unset DATABASE_URL` to fix this.
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "express": "^5.2.1",
     "fuzzysort": "^3.1.0",
     "got-scraping": "^4.2.1",
+    "helmet": "^8.1.0",
     "nest-commander": "^3.20.1",
     "nestjs-pino": "^4.6.1",
     "pg": "^8.20.0",

--- a/apps/api/src/bootstrap/__tests__/assert-cors-origin.spec.ts
+++ b/apps/api/src/bootstrap/__tests__/assert-cors-origin.spec.ts
@@ -1,0 +1,49 @@
+import { assertCorsOriginConfigured } from '../assert-cors-origin';
+
+describe('assertCorsOriginConfigured', () => {
+  it('returns the value when production and CORS_ORIGIN is set', () => {
+    const result = assertCorsOriginConfigured({
+      NODE_ENV: 'production',
+      CORS_ORIGIN: 'https://app.example.com',
+    });
+    expect(result).toBe('https://app.example.com');
+  });
+
+  it('throws when production and CORS_ORIGIN is missing', () => {
+    expect(() => assertCorsOriginConfigured({ NODE_ENV: 'production' })).toThrow(
+      /CORS_ORIGIN must be set in production/,
+    );
+  });
+
+  it('throws when production and CORS_ORIGIN is an empty string', () => {
+    expect(() => assertCorsOriginConfigured({ NODE_ENV: 'production', CORS_ORIGIN: '' })).toThrow(
+      /CORS_ORIGIN must be set in production/,
+    );
+  });
+
+  it('throws when production and CORS_ORIGIN is only whitespace', () => {
+    expect(() =>
+      assertCorsOriginConfigured({ NODE_ENV: 'production', CORS_ORIGIN: '   ' }),
+    ).toThrow(/CORS_ORIGIN must be set in production/);
+  });
+
+  it('returns undefined when NODE_ENV is development and CORS_ORIGIN is missing', () => {
+    expect(assertCorsOriginConfigured({ NODE_ENV: 'development' })).toBeUndefined();
+  });
+
+  it('returns undefined when NODE_ENV is test and CORS_ORIGIN is missing', () => {
+    expect(assertCorsOriginConfigured({ NODE_ENV: 'test' })).toBeUndefined();
+  });
+
+  it('returns the value when NODE_ENV is development and CORS_ORIGIN is set', () => {
+    const result = assertCorsOriginConfigured({
+      NODE_ENV: 'development',
+      CORS_ORIGIN: 'http://localhost:3000',
+    });
+    expect(result).toBe('http://localhost:3000');
+  });
+
+  it('returns undefined when NODE_ENV is unset and CORS_ORIGIN is missing', () => {
+    expect(assertCorsOriginConfigured({})).toBeUndefined();
+  });
+});

--- a/apps/api/src/bootstrap/__tests__/helmet-headers.spec.ts
+++ b/apps/api/src/bootstrap/__tests__/helmet-headers.spec.ts
@@ -1,0 +1,67 @@
+import { Controller, Get, INestApplication, Module } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import helmet from 'helmet';
+import request from 'supertest';
+
+// Real HTTP integration test: boots a minimal Nest app with helmet wired the
+// same way as main.ts and asserts the response carries the hardening headers
+// we care about for a JSON-only API.
+
+@Controller('dummy')
+class DummyController {
+  @Get('ping')
+  ping() {
+    return { ok: true };
+  }
+}
+
+@Module({ controllers: [DummyController] })
+class DummyModule {}
+
+describe('helmet security headers', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({ imports: [DummyModule] }).compile();
+    app = module.createNestApplication();
+    app.getHttpAdapter().getInstance().set('trust proxy', 1);
+    app.use(helmet());
+    app.enableCors({ origin: 'https://app.example.com' });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('sets X-Content-Type-Options: nosniff', async () => {
+    const res = await request(app.getHttpServer()).get('/dummy/ping');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('sets a Referrer-Policy header', async () => {
+    const res = await request(app.getHttpServer()).get('/dummy/ping');
+    expect(res.headers['referrer-policy']).toBeDefined();
+  });
+
+  it('emits Strict-Transport-Security when the request is forwarded as HTTPS', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/dummy/ping')
+      .set('X-Forwarded-Proto', 'https');
+    expect(res.headers['strict-transport-security']).toMatch(/max-age=/);
+  });
+
+  it('removes the X-Powered-By header', async () => {
+    const res = await request(app.getHttpServer()).get('/dummy/ping');
+    expect(res.headers['x-powered-by']).toBeUndefined();
+  });
+
+  it('honors the configured CORS origin on a preflight request', async () => {
+    const res = await request(app.getHttpServer())
+      .options('/dummy/ping')
+      .set('Origin', 'https://app.example.com')
+      .set('Access-Control-Request-Method', 'GET');
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example.com');
+  });
+});

--- a/apps/api/src/bootstrap/assert-cors-origin.ts
+++ b/apps/api/src/bootstrap/assert-cors-origin.ts
@@ -1,0 +1,14 @@
+// Fails loudly at boot if CORS_ORIGIN is missing in production. The fallback
+// to localhost is intentional for dev ergonomics, but in prod a missing value
+// means the frontend will silently break — we'd rather crash the container
+// with a clear error than ship a useless CORS policy and get a bug report
+// hours later.
+export function assertCorsOriginConfigured(env: NodeJS.ProcessEnv): string | undefined {
+  const corsOrigin = env.CORS_ORIGIN?.trim();
+  if (env.NODE_ENV === 'production' && !corsOrigin) {
+    throw new Error(
+      'CORS_ORIGIN must be set in production. Configure it in Dokploy environment variables.',
+    );
+  }
+  return corsOrigin || undefined;
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,11 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { json, Request, Response } from 'express';
+import helmet from 'helmet';
 import { randomUUID } from 'node:crypto';
 import { Logger } from 'nestjs-pino';
 import { AppModule } from './app.module';
 import { AllExceptionsFilter } from './infrastructure/observability/all-exceptions.filter';
 import { CorrelationStore } from './infrastructure/observability/correlation.store';
+import { assertCorsOriginConfigured } from './bootstrap/assert-cors-origin';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
@@ -25,11 +27,11 @@ async function bootstrap() {
   });
 
   app.useGlobalFilters(app.get(AllExceptionsFilter));
+  app.use(helmet());
   app.use(json({ limit: '5mb' }));
 
-  app.enableCors({
-    origin: process.env.CORS_ORIGIN ?? 'http://localhost:3000',
-  });
+  const corsOrigin = assertCorsOriginConfigured(process.env);
+  app.enableCors({ origin: corsOrigin ?? 'http://localhost:3000' });
   app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
   app.enableShutdownHooks();
 

--- a/docs/runbooks/runbook-prod.md
+++ b/docs/runbooks/runbook-prod.md
@@ -243,6 +243,7 @@ Or filter by service across both containers in one query:
 3. Verify ML service is healthy (API requires it for all scoring — there is no fallback)
 4. Check disk space: `df -h`
 5. Check for missing required environment variables in Dokploy env settings
+6. If logs show `CORS_ORIGIN must be set in production`, the fail-fast guard caught a missing env var. Add `CORS_ORIGIN` in Dokploy > Service > Environment with the web frontend URL (e.g. `https://cycling.yourdomain.com`) and redeploy.
 
 ### ML service unhealthy
 
@@ -311,6 +312,8 @@ Or filter by service across both containers in one query:
 | Bulk scraping      | CLI/cron only — no REST endpoint triggers batch scrapes                                                                                                                                                                                                                                        |
 | On-demand scraping | REST endpoints restricted by hostname allow-list (PCS, GMV)                                                                                                                                                                                                                                    |
 | Rate limiting      | Global 60/min per IP; 5/min on `/api/analyze`; 15/min on external-scrape routes (`/api/race-profile`, `/api/race-profile-by-slug`, `/api/import-price-list`, `/api/gmv-match`). Requires `trust proxy: 1` in `main.ts` so `req.ip` is the real client behind Traefik, not the proxy container. |
+| HTTP headers       | `helmet()` with defaults — emits `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Strict-Transport-Security` (when forwarded as HTTPS), and removes `X-Powered-By`. JSON-only API, so CSP/frameguard are inert but harmless.                                                             |
+| CORS               | `CORS_ORIGIN` is **required** when `NODE_ENV=production`. Missing value crashes the container at boot instead of silently serving with a useless localhost policy.                                                                                                                             |
 | Database           | Not exposed publicly — accessible only via internal Docker network                                                                                                                                                                                                                             |
 | Secrets            | Managed via Dokploy environment variables, not committed to repo                                                                                                                                                                                                                               |
 | OS updates         | Applied monthly on VPS                                                                                                                                                                                                                                                                         |
@@ -382,14 +385,14 @@ SEED_YEARS=3 ./scripts/weekly-pipeline.sh
 
 ### API (`cycling-api`)
 
-| Variable                | Example                                   | Description                                                     |
-| ----------------------- | ----------------------------------------- | --------------------------------------------------------------- |
-| `DATABASE_URL`          | `postgresql://user:pass@host:5432/dbname` | PostgreSQL connection string (hostname from Dokploy DB service) |
-| `PORT`                  | `3001`                                    | API listen port                                                 |
-| `CORS_ORIGIN`           | `https://cycling.yourdomain.com`          | Allowed origin for web frontend                                 |
-| `ML_SERVICE_URL`        | `http://ml-service:8000`                  | Internal ML service URL                                         |
-| `PCS_REQUEST_DELAY_MS`  | `1500`                                    | Delay between PCS scraping requests (ms)                        |
-| `FUZZY_MATCH_THRESHOLD` | `-10000`                                  | Rider name fuzzy matching threshold                             |
+| Variable                | Example                                   | Description                                                                                                                                            |
+| ----------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `DATABASE_URL`          | `postgresql://user:pass@host:5432/dbname` | PostgreSQL connection string (hostname from Dokploy DB service)                                                                                        |
+| `PORT`                  | `3001`                                    | API listen port                                                                                                                                        |
+| `CORS_ORIGIN`           | `https://cycling.yourdomain.com`          | **Required in production.** Allowed origin for web frontend. The API crashes on boot with a clear error if this is missing when `NODE_ENV=production`. |
+| `ML_SERVICE_URL`        | `http://ml-service:8000`                  | Internal ML service URL                                                                                                                                |
+| `PCS_REQUEST_DELAY_MS`  | `1500`                                    | Delay between PCS scraping requests (ms)                                                                                                               |
+| `FUZZY_MATCH_THRESHOLD` | `-10000`                                  | Rider name fuzzy matching threshold                                                                                                                    |
 
 ### Web (`cycling-web`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       got-scraping:
         specifier: ^4.2.1
         version: 4.2.1
+      helmet:
+        specifier: ^8.1.0
+        version: 8.1.0
       nest-commander:
         specifier: ^3.20.1
         version: 3.20.1(@nestjs/common@11.1.16)(@nestjs/core@11.1.16)(@types/inquirer@8.2.12)(@types/node@22.19.15)(typescript@5.9.3)
@@ -7217,6 +7220,11 @@ packages:
       generative-bayesian-network: 2.1.81
       ow: 0.28.2
       tslib: 2.8.1
+    dev: false
+
+  /helmet@8.1.0:
+    resolution: {integrity: sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==}
+    engines: {node: '>=18.0.0'}
     dev: false
 
   /help-me@5.0.0:


### PR DESCRIPTION
Closes #70.

## Summary

Two production hardening gaps in `apps/api/src/main.ts`:

1. **CORS silently fell back to `http://localhost:3000`** when `CORS_ORIGIN` was unset. Today it's configured in Dokploy so nothing is broken, but a future redeploy with a missing env var would ship with a useless CORS policy and the frontend would break silently in the browser — a bug report the next morning instead of a loud failure at deploy time. Since CORS only protects *browser* clients and this API is JSON-only with no auth or cookies, the impact is operational (silent breakage), not a data-exposure vuln, but fail-fast on a required env var is cheap and correct.
2. **No `helmet` middleware.** Most helmet defaults are inert on a JSON API (CSP, frameguard) but `X-Content-Type-Options: nosniff`, `Referrer-Policy`, and `Strict-Transport-Security` (honored when the request arrives with `X-Forwarded-Proto=https`, which the `trust proxy: 1` from #73 already handles) are essentially free defense-in-depth. `X-Powered-By` also gets removed.

## Changes

- **`bootstrap/assert-cors-origin.ts`** — small helper extracted for testability. Throws in `NODE_ENV=production` when `CORS_ORIGIN` is missing, empty, or whitespace-only. Returns the trimmed value otherwise, or `undefined` in dev so `main.ts` can apply the localhost fallback.
- **`main.ts`** — registers `helmet()` before other middleware and uses the helper to guard CORS. Dev behaviour unchanged (falls back to `http://localhost:3000`).
- **Docs:**
  - `docs/runbooks/runbook-prod.md` Security Checklist: new rows for HTTP headers and CORS policy
  - `docs/runbooks/runbook-prod.md` §Troubleshooting "API won't start": call out the exact error message (`CORS_ORIGIN must be set in production`) and the exact fix (add the var in Dokploy)
  - `docs/runbooks/runbook-prod.md` §Environment Variables: mark `CORS_ORIGIN` as **required in production**
  - `README.md`: same flag in the env var table
  - `.env.example`: add a commented `CORS_ORIGIN` line so the var is discoverable when cloning the repo

## What I explicitly did not do

- **No custom helmet config.** Defaults are correct for a JSON API behind Traefik. Tuning individual headers without a concrete problem is premature.
- **No CSP overrides.** CSP governs HTML documents; a JSON API never renders any, so the default is inert and harmless.
- **No HSTS preload.** Separate decision that affects the whole domain — out of scope.
- **No CORS methods/headers restrictions.** `enableCors` defaults are fine for our use case.
- **No validation that `CORS_ORIGIN` is a well-formed URL** — the fail-fast only catches empty/missing. If someone misconfigures with a typo the browser will still complain, but that's a Dokploy-side verification, not a runtime check in the API.

## Test plan

- [x] `apps/api` full test suite — 514 pass (501 prior + 13 new)
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] Unit tests on the helper cover: production+set, production+missing, production+empty string, production+whitespace-only, dev+missing (returns undefined), test env, dev+set, `NODE_ENV` undefined
- [x] Integration test (supertest + minimal Nest app) asserts the real response headers helmet emits:
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy` present
  - `Strict-Transport-Security` when request carries `X-Forwarded-Proto: https`
  - `X-Powered-By` removed
  - CORS preflight returns the configured origin
- [ ] After merge: verify the prod container boots cleanly and that the expected headers show up on the real API via `curl -I https://<api-host>/health/liveness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
