### PR TITLE
chore(api): fail fast if DATABASE_URL is missing in drizzle provider

### DIFF
--- a/apps/api/src/infrastructure/database/drizzle.provider.ts
+++ b/apps/api/src/infrastructure/database/drizzle.provider.ts
@@ -9,10 +9,11 @@ export type DrizzleDatabase = NodePgDatabase<typeof schema>;
 export const drizzleProvider = {
   provide: DRIZZLE,
   useFactory: (): DrizzleDatabase => {
-    const pool = new Pool({
-      connectionString:
-        process.env.DATABASE_URL ?? 'postgresql://cycling:cycling@localhost:5432/cycling_analyzer',
-    });
+    const connectionString = process.env.DATABASE_URL;
+    if (!connectionString) {
+      throw new Error('DATABASE_URL environment variable is required');
+    }
+    const pool = new Pool({ connectionString });
     return drizzle(pool, { schema });
   },
 };


### PR DESCRIPTION
Closes #71.

## Summary

`drizzle.provider.ts` used to silently fall back to a hardcoded local connection string when `DATABASE_URL` was unset:

```ts
connectionString:
  process.env.DATABASE_URL ?? 'postgresql://cycling:cycling@localhost:5432/cycling_analyzer',
```

Three specific smells:

1. **Hides misconfigurations.** A future Dokploy redeploy without the var would start, create a `pg` `Pool` targeting a non-existent `localhost` inside the container, and only fail on the first real query — likely showing up as a confusing 5xx on the first user request rather than a clear crash at boot.
2. **Inconsistent with its sibling.** `apps/api/src/infrastructure/database/run-migrations.ts:12-14` already throws with exactly the same rule. Two policies for the same env var in the same layer → the wrong one eventually gets copied.
3. **Placeholder credentials in source.** Even though they're the same as local dev defaults, they shouldn't live in `src/`.

Fix: mirror `run-migrations.ts` word-for-word.

```ts
useFactory: (): DrizzleDatabase => {
  const connectionString = process.env.DATABASE_URL;
  if (!connectionString) {
    throw new Error('DATABASE_URL environment variable is required');
  }
  const pool = new Pool({ connectionString });
  return drizzle(pool, { schema });
},
```

## Why this is safe for CI

`test.yml` runs API unit tests **without** setting `DATABASE_URL`, so I verified the factory is never actually exercised by tests before pushing:

- No spec imports `AppModule` or `DatabaseModule` (checked via grep).
- The only spec that touches the `DRIZZLE` token (`throttle.spec.ts`) overrides it with `{ provide: DRIZZLE, useValue: ... }`, so Nest uses the override instead of calling the factory.
- `e2e.yml`, Dokploy, and local dev `.env` all set `DATABASE_URL`, so the real boot path stays green.

## Test plan

- [x] `apps/api` full test suite — 501 pass (no change; the factory is never invoked from tests)
- [x] `make lint` — clean
- [x] `make typecheck` — clean
- [x] Verified no spec imports `AppModule` / `DatabaseModule` / `drizzleProvider`
- [ ] After merge: confirm the prod container boots cleanly (it will, because Dokploy sets the var)

## What I explicitly did not do

- **No new unit test.** Testing a `useFactory` would require bootstrapping Nest or exercising it in isolation; `run-migrations.ts` has the same logic without a test, and adding one only here would be asymmetric. If we want to consolidate, it should be its own chore that also covers `run-migrations.ts`.
- **No docs changes.** The runbook and `.env.example` already list `DATABASE_URL` as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
