### PR TITLE
fix(api): load monorepo-root .env in local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ The web frontend runs at `http://localhost:3000` and the API at `http://localhos
 
 ## Environment Variables
 
-The API uses `@nestjs/config` to load env files with this priority:
+The API uses `@nestjs/config` to load env files with this priority (both live at the **repo root**, not inside `apps/api/`):
 
 1. **`.env.local`** — personal overrides, gitignored
 2. **`.env`** — local defaults, gitignored (copy from `.env.example`)
 
-Both are optional. If neither exists, built-in defaults apply.
+Both are optional during boot, but `DATABASE_URL` is required — the API fails fast at startup if it is missing. Either define it in one of the files above or export it in your shell.
 
 | Variable                      | Default                                                        | Description                                                                                                     |
 | ----------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -13,7 +13,10 @@ import { HealthController } from './presentation/health.controller';
 @Module({
   imports: [
     ConfigModule.forRoot({
-      envFilePath: ['.env.local', '.env'],
+      // Local dev cwd is `apps/api/`, so we also look at the monorepo root (`../../`)
+      // where the shared `.env` actually lives. In Docker, cwd is `/app` and env vars
+      // are injected directly — these paths just resolve to nothing and are ignored.
+      envFilePath: ['.env.local', '.env', '../../.env.local', '../../.env'],
       isGlobal: true,
     }),
     ThrottlerModule.forRoot({


### PR DESCRIPTION
## Summary

`make dev` was crashing on boot with `Error: DATABASE_URL environment variable is required`, even with `DATABASE_URL` correctly defined in the repo-root `.env`.

**Root cause**: `make dev` invokes `pnpm --filter @cycling-analyzer/api run dev`, which sets `cwd=apps/api/` before booting Nest. `ConfigModule.forRoot({ envFilePath: ['.env.local', '.env'] })` resolves those paths against `cwd`, so it was looking at `apps/api/.env` — which doesn't exist. The shared `.env` lives at the **repo root**.

This was a pre-existing bug, but it was masked: the Drizzle provider used to accept `undefined` silently and defer the failure to first DB query. PR #75 (`chore(api): fail fast if DATABASE_URL is missing in drizzle provider`) added a strict check and exposed it.

## Fix

Add the parent-relative paths to `envFilePath`:

```ts
envFilePath: ['.env.local', '.env', '../../.env.local', '../../.env'],
```

- From `cwd=apps/api/`, `../../.env` → repo-root `.env` → DATABASE_URL loaded ✅
- From `cwd=/app` in Docker, `../../.env` → `/.env` → doesn't exist, harmlessly ignored. Production env vars are injected by Dokploy directly, not via file ✅

Verified locally: with this change, `dotenv.config({ path: '../../.env' })` from `apps/api/` loads 5 keys including `DATABASE_URL`.

## Doc updates

- README "Environment Variables" section now states explicitly that `.env` / `.env.local` live at the repo root, and that `DATABASE_URL` is required (fail-fast).

## Test plan

- [x] Full API test suite green (523/523)
- [x] `make lint` clean
- [x] Typecheck clean
- [x] Verified `../../.env` resolves to repo-root `.env` from `apps/api/` cwd
- [ ] Confirm `make dev` boots cleanly with only repo-root `.env` (no `apps/api/.env`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)